### PR TITLE
(bug fix) Issue #20

### DIFF
--- a/Stardrop/Views/SettingsWindow.axaml.cs
+++ b/Stardrop/Views/SettingsWindow.axaml.cs
@@ -90,11 +90,11 @@ namespace Stardrop.Views
             }
             else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             {
-                dialog.Filters.Add(new FileDialogFilter() { Name = "StardewModdingAPI" });
+                dialog.Filters.Add(new FileDialogFilter() { Name = "Stardew Valley" });
             }
             else
             {
-                dialog.Filters.Add(new FileDialogFilter() { Name = "StardewModdingAPI", Extensions = { "*" } });
+                dialog.Filters.Add(new FileDialogFilter() { Name = "Stardew Valley", Extensions = { "*" } });
             }
             dialog.AllowMultiple = false;
 
@@ -135,11 +135,10 @@ namespace Stardrop.Views
                 return;
             }
 
-
             var targetSmapiName = "StardewModdingAPI.exe";
             if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
-                targetSmapiName = "StardewModdingAPI";
+                targetSmapiName = "Stardew Valley";
             }
 
             var smapiFileInfo = new FileInfo(filePaths[0]);


### PR DESCRIPTION
The filename `StardewModdingAPI` is hardcoded for macOS and all other operating systems, when it should be `Stardew Valley`, as the SMAPI installer changes the names of the files around (as explained in #20.)

Also removed an extra blank line for neatness 🙂