### PR TITLE
Bump .NET version to 7.0

### DIFF
--- a/Stardrop/Properties/PublishProfiles/FolderProfile - Linux.pubxml
+++ b/Stardrop/Properties/PublishProfiles/FolderProfile - Linux.pubxml
@@ -8,10 +8,9 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <Platform>Any CPU</Platform>
     <PublishDir>publish\linux</PublishDir>
     <PublishProtocol>FileSystem</PublishProtocol>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <RuntimeIdentifier>linux-x64</RuntimeIdentifier>
     <SelfContained>true</SelfContained>
-    <PublishSingleFile>True</PublishSingleFile>
-    <PublishTrimmed>True</PublishTrimmed>
+    <PublishSingleFile>true</PublishSingleFile>
   </PropertyGroup>
 </Project>

--- a/Stardrop/Properties/PublishProfiles/FolderProfile - MacOS.pubxml
+++ b/Stardrop/Properties/PublishProfiles/FolderProfile - MacOS.pubxml
@@ -8,10 +8,9 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <Platform>Any CPU</Platform>
     <PublishDir>publish\mac</PublishDir>
     <PublishProtocol>FileSystem</PublishProtocol>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <RuntimeIdentifier>osx-x64</RuntimeIdentifier>
     <SelfContained>true</SelfContained>
-    <PublishSingleFile>True</PublishSingleFile>
-    <PublishTrimmed>True</PublishTrimmed>
+    <PublishSingleFile>true</PublishSingleFile>
   </PropertyGroup>
 </Project>

--- a/Stardrop/Properties/PublishProfiles/FolderProfile - Windows.pubxml
+++ b/Stardrop/Properties/PublishProfiles/FolderProfile - Windows.pubxml
@@ -8,11 +8,10 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <Platform>Any CPU</Platform>
     <PublishDir>publish\windows</PublishDir>
     <PublishProtocol>FileSystem</PublishProtocol>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     <SelfContained>true</SelfContained>
-    <PublishSingleFile>True</PublishSingleFile>
-    <PublishReadyToRun>False</PublishReadyToRun>
-    <PublishTrimmed>True</PublishTrimmed>
+    <PublishSingleFile>true</PublishSingleFile>
+    <PublishReadyToRun>false</PublishReadyToRun>
   </PropertyGroup>
 </Project>

--- a/Stardrop/Stardrop.csproj
+++ b/Stardrop/Stardrop.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<OutputType>WinExe</OutputType>
-		<TargetFramework>net5.0</TargetFramework>
+		<TargetFramework>net7.0</TargetFramework>
 		<Nullable>enable</Nullable>
 		<Version>1.0.0-beta.38</Version>
 		<AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>


### PR DESCRIPTION
This PR bumps .NET version to .NET 7. I am not aware of any problems caused by this update.

.NET 5 is out of support. .NET 8 on my system already throws warnings when compiling for .NET 5. All Flatpak tooling is currently using .NET 7 as the latest .NET version.

Stardrop compiles and works without any issues under .NET 7 on Linux, but I cannot verify this on MacOS and Windows, as I do not have any of those systems.