### PR TITLE
Update Semver package and resolve Semver deprecation warnings

### DIFF
--- a/Stardrop/Models/Mod.cs
+++ b/Stardrop/Models/Mod.cs
@@ -112,7 +112,7 @@ namespace Stardrop.Models
             ModFileInfo = modFileInfo;
 
             UniqueId = uniqueId;
-            Version = SemVersion.TryParse(version, out var parsedVersion) ? parsedVersion : new SemVersion(0, 0, 0, "bad-version");
+            Version = SemVersion.TryParse(version, SemVersionStyles.Any, out var parsedVersion) ? parsedVersion : SemVersion.ParsedFrom(0, 0, 0, "bad-version");
             Name = String.IsNullOrEmpty(name) ? uniqueId : name;
             Description = String.IsNullOrEmpty(description) ? String.Empty : description;
             Author = String.IsNullOrEmpty(author) ? Program.translation.Get("internal.unknown") : author;
@@ -127,7 +127,7 @@ namespace Stardrop.Models
                 return false;
             }
 
-            return SemVersion.Parse(version) > Version;
+            return SemVersion.Parse(version, SemVersionStyles.Any).CompareSortOrderTo(Version) > 0;
         }
 
         public bool HasValidVersion()

--- a/Stardrop/Stardrop.csproj
+++ b/Stardrop/Stardrop.csproj
@@ -42,7 +42,7 @@
 		<PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />
 		<PackageReference Include="Projektanker.Icons.Avalonia" Version="5.2.0" />
 		<PackageReference Include="Projektanker.Icons.Avalonia.MaterialDesign" Version="5.2.0" />
-		<PackageReference Include="semver" Version="2.2.0" />
+		<PackageReference Include="semver" Version="2.3.0" />
 		<PackageReference Include="SharpCompress" Version="0.32.1" />
 	</ItemGroup>
 	<ItemGroup>

--- a/Stardrop/ViewModels/MainWindowViewModel.cs
+++ b/Stardrop/ViewModels/MainWindowViewModel.cs
@@ -247,10 +247,10 @@ namespace Stardrop.ViewModels
                     {
                         Mods.Add(mod);
                     }
-                    else if (Mods.FirstOrDefault(m => m.UniqueId.Equals(manifest.UniqueID, StringComparison.OrdinalIgnoreCase) && m.Version < mod.Version) is Mod oldMod && oldMod is not null)
+                    else if (Mods.FirstOrDefault(m => m.UniqueId.Equals(manifest.UniqueID, StringComparison.OrdinalIgnoreCase) && m.Version.CompareSortOrderTo(mod.Version) < 0) is Mod oldMod && oldMod is not null)
                     {
                         // Replace old mod with newer one
-                        int oldModIndex = Mods.IndexOf(Mods.First(m => m.UniqueId.Equals(manifest.UniqueID, StringComparison.OrdinalIgnoreCase) && m.Version < mod.Version));
+                        int oldModIndex = Mods.IndexOf(Mods.First(m => m.UniqueId.Equals(manifest.UniqueID, StringComparison.OrdinalIgnoreCase) && m.Version.CompareSortOrderTo(mod.Version) < 0));
                         Mods[oldModIndex] = mod;
                     }
                 }

--- a/Stardrop/Views/MainWindow.axaml.cs
+++ b/Stardrop/Views/MainWindow.axaml.cs
@@ -225,7 +225,7 @@ namespace Stardrop.Views
             {
                 Program.settings.Version = _viewModel.Version.Replace("v", String.Empty);
             }
-            else if (SemVersion.TryParse(Program.settings.Version, SemVersionStyles.Any, out var cachedVersion) && SemVersion.TryParse(_viewModel.Version.Replace("v", String.Empty), SemVersionStyles.Any, out var currentVersion) && cachedVersion < currentVersion)
+            else if (SemVersion.TryParse(Program.settings.Version, SemVersionStyles.Any, out var cachedVersion) && SemVersion.TryParse(_viewModel.Version.Replace("v", String.Empty), SemVersionStyles.Any, out var currentVersion) && cachedVersion.CompareSortOrderTo(currentVersion) < 0)
             {
                 // Display message with link to release notes
                 var requestWindow = new MessageWindow(Program.translation.Get("ui.message.stardrop_update_complete"));
@@ -1028,7 +1028,7 @@ namespace Stardrop.Views
 
             // Check if current version is the latest
             var versionToUri = await GitHub.GetLatestStardropRelease();
-            if (versionToUri is not null && SemVersion.TryParse(versionToUri?.Key.Replace("v", String.Empty), out latestVersion) && SemVersion.TryParse(_viewModel.Version.Replace("v", String.Empty), out var currentVersion) && latestVersion > currentVersion)
+            if (versionToUri is not null && SemVersion.TryParse(versionToUri?.Key.Replace("v", String.Empty), out latestVersion) && SemVersion.TryParse(_viewModel.Version.Replace("v", String.Empty), out var currentVersion) && latestVersion.CompareSortOrderTo(currentVersion) > 0)
             {
                 updateAvailable = true;
             }
@@ -1156,7 +1156,7 @@ namespace Stardrop.Views
             }
 
             KeyValuePair<string, string>? latestSmapiToUri = await GitHub.GetLatestSMAPIRelease();
-            if (latestSmapiToUri is not null && SemVersion.TryParse(latestSmapiToUri?.Key, SemVersionStyles.Any, out var latestVersion) && currentSmapiVersion is not null && latestVersion > currentSmapiVersion)
+            if (latestSmapiToUri is not null && SemVersion.TryParse(latestSmapiToUri?.Key, SemVersionStyles.Any, out var latestVersion) && currentSmapiVersion is not null && latestVersion.CompareSortOrderTo(currentSmapiVersion) > 0)
             {
                 var confirmationWindow = new MessageWindow(String.Format(Program.translation.Get("ui.message.SMAPI_update_available"), latestVersion));
                 if (await confirmationWindow.ShowDialog<bool>(this) is false)


### PR DESCRIPTION
This PR updates Semver package to version 2.3.0 and fixes the deprecation warnings caused by using operator `<` to compare versions directly and `SemVersion` constructor.

The PR should introduce not changes other than replacing the deprecated operator `<` with the recommended `.CompareSortOrderTo()`, as per [Semver documentation](https://semver-nuget.org/v2.3.x/index.html).

Tested on Linux, but not on Windows and MacOS.