### PR TITLE
Match `Manifest.json` files as well

### DIFF
--- a/Stardrop/ViewModels/MainWindowViewModel.cs
+++ b/Stardrop/ViewModels/MainWindowViewModel.cs
@@ -156,14 +156,14 @@ namespace Stardrop.ViewModels
             {
                 try
                 {
-                    var localManifest = directory.EnumerateFiles().Where(file => file.Name.Equals("manifest.json", StringComparison.OrdinalIgnoreCase));
-                    if (localManifest.Count() == 0)
+                    var localManifest = directory.EnumerateFiles().FirstOrDefault(file => file.Name.Equals("manifest.json", StringComparison.OrdinalIgnoreCase));
+                    if (localManifest is null)
                     {
                         manifests.AddRange(GetManifestFiles(directory));
                     }
                     else
                     {
-                        manifests.Add(localManifest.First());
+                        manifests.Add(localManifest);
                     }
                 }
                 catch (Exception ex)

--- a/Stardrop/ViewModels/MainWindowViewModel.cs
+++ b/Stardrop/ViewModels/MainWindowViewModel.cs
@@ -156,7 +156,7 @@ namespace Stardrop.ViewModels
             {
                 try
                 {
-                    var localManifest = directory.EnumerateFiles("manifest.json");
+                    var localManifest = directory.EnumerateFiles().Where(file => file.Name.Equals("manifest.json", StringComparison.OrdinalIgnoreCase));
                     if (localManifest.Count() == 0)
                     {
                         manifests.AddRange(GetManifestFiles(directory));


### PR DESCRIPTION
This PR fixes once place in the code where variations of `manifest.json`, namely `Manifest.json`, are not considered, resulting in omission of some mods from the mod list.

Tested on Linux, not tested on Windows or MacOS.

[Example mod](https://www.nexusmods.com/stardewvalley/mods/9137) with `Manifest.json` for testing purposes.