### PR TITLE
Update translation key 'ui.window.setting' to 'ui.window.settings'

### DIFF
--- a/Stardrop/Views/SettingsWindow.axaml
+++ b/Stardrop/Views/SettingsWindow.axaml
@@ -171,7 +171,7 @@
 		<Border Grid.Row="0" BorderBrush="{DynamicResource HighlightBrush}" BorderThickness="0 0 0 2" Grid.ColumnSpan="2">
 			<Menu Name="menuBar" KeyboardNavigation.TabNavigation="None">
 				<Image Source="/Assets/icon.ico" Stretch="None"/>
-				<TextBlock Text="{i18n:Translate ui.window.setting.name}" Margin="-10 0 0 0" VerticalAlignment="Center" HorizontalAlignment="Left" Foreground="{DynamicResource ThemeForegroundBrush}" />
+				<TextBlock Text="{i18n:Translate ui.window.settings.name}" Margin="-10 0 0 0" VerticalAlignment="Center" HorizontalAlignment="Left" Foreground="{DynamicResource ThemeForegroundBrush}" />
 			</Menu>
 		</Border>
 		<Menu Name="windowMenu" IsVisible="{Binding ShowMainMenu}" HorizontalAlignment="Right" KeyboardNavigation.TabNavigation="None" Grid.Column="1">

--- a/Stardrop/i18n/de.json
+++ b/Stardrop/i18n/de.json
@@ -117,7 +117,7 @@
   "ui.message.confirm_mod_update_method": "Es wurde eine frühere Version von {0} erkannt. Möchtest du die vorherige Installation löschen?\n\nHinweis: Das Löschen früherer Versionen wird normalerweise empfohlen, allerdings gehen dabei alle Konfig Dateien verloren.",
 
   // Window Names
-  "ui.window.setting.name": "Einstellungen",
+  "ui.window.settings.name": "Einstellungen",
   "ui.window.profiles.name": "Profile",
   "ui.window.profile_naming.name": "Profil Name",
 

--- a/Stardrop/i18n/default.json
+++ b/Stardrop/i18n/default.json
@@ -190,7 +190,7 @@
   "ui.message.succeeded_nexus_install": "Successfully installed the following mod via Nexus Mods:\n\n{0}",
 
   // Window Names
-  "ui.window.setting.name": "Settings",
+  "ui.window.settings.name": "Settings",
   "ui.window.profiles.name": "Profiles",
   "ui.window.profile_naming.name": "Profile Name",
   "ui.window.nexus_login.name": "Nexus Mods Personal API Key",

--- a/Stardrop/i18n/es.json
+++ b/Stardrop/i18n/es.json
@@ -187,7 +187,7 @@
   "ui.message.succeeded_nexus_install": "Instalado con éxito el siguiente mod a través de Nexus Mods:\n\n{0}",
   
   // Window Names
-  "ui.window.setting.name": "Ajustes",
+  "ui.window.settings.name": "Ajustes",
   "ui.window.profiles.name": "Perfiles",
   "ui.window.profile_naming.name": "Nombre De Perfil",
   "ui.window.nexus_login.name": "Clave API personal de Nexus Mods",

--- a/Stardrop/i18n/fr.json
+++ b/Stardrop/i18n/fr.json
@@ -119,7 +119,7 @@
     "ui.message.confirm_mod_update_method": "Une version antèrieure de {0} a été détecté. Voulez-vous supprimer l'ancienne version?\n\nNote: Supprimer les versions antèrieures est souvent recommandé. Les configurations seront en revanche perdues..",
   
     // Window Names
-    "ui.window.setting.name": "Paramètres",
+    "ui.window.settings.name": "Paramètres",
     "ui.window.profiles.name": "Profils",
     "ui.window.profile_naming.name": "Non Du Profil",
   

--- a/Stardrop/i18n/hu.json
+++ b/Stardrop/i18n/hu.json
@@ -190,7 +190,7 @@
   "ui.message.succeeded_nexus_install": "A Nexus mods segítségével sikeresen telepítve a következő mod:\n\n{0}",
 
   // Ablak nevek
-  "ui.window.setting.name": "Beállítások",
+  "ui.window.settings.name": "Beállítások",
   "ui.window.profiles.name": "Profilok",
   "ui.window.profile_naming.name": "Profil név",
   "ui.window.nexus_login.name": "Nexus mods személyes API kulcs",

--- a/Stardrop/i18n/it.json
+++ b/Stardrop/i18n/it.json
@@ -117,7 +117,7 @@
   "ui.message.confirm_mod_update_method": "É stata rilevata una versione precedente di {0}. Vuoi eliminare la precedente installazione?\n\nNota: Eliminare ogni versione precedente è in genere raccomandato, ogni file di configurazione andrà però perso.",
 
   // Window Names
-  "ui.window.setting.name": "Impostazioni",
+  "ui.window.settings.name": "Impostazioni",
   "ui.window.profiles.name": "Profili",
   "ui.window.profile_naming.name": "Nome Profilo",
 

--- a/Stardrop/i18n/pt.json
+++ b/Stardrop/i18n/pt.json
@@ -190,7 +190,7 @@
   "ui.message.succeeded_nexus_install": "O mod seguinte foi instalado via Nexus Mods:\n\n{0}",
 
   // Window Names
-  "ui.window.setting.name": "Configurações",
+  "ui.window.settings.name": "Configurações",
   "ui.window.profiles.name": "Perfis",
   "ui.window.profile_naming.name": "Nome do perfil",
   "ui.window.nexus_login.name": "Chave API pessoal do Nexus Mods",

--- a/Stardrop/i18n/ru.json
+++ b/Stardrop/i18n/ru.json
@@ -190,7 +190,7 @@
   "ui.message.succeeded_nexus_install": "Успешно установлен следующий мод через Nexus Mods:\n\n{0}",
 
   // Window Names
-  "ui.window.setting.name": "Настройки",
+  "ui.window.settings.name": "Настройки",
   "ui.window.profiles.name": "Профили",
   "ui.window.profile_naming.name": "Название профиля",
   "ui.window.nexus_login.name": "Личный ключ API Nexus Mods",

--- a/Stardrop/i18n/th.json
+++ b/Stardrop/i18n/th.json
@@ -117,7 +117,7 @@
   "ui.message.confirm_mod_update_method": "ตรวจพบ {0} เวอร์ชันก่อนหน้าแล้ว คุณต้องการล้างการติดตั้งก่อนหน้านี้หรือไม่?\n\nหมายเหตุ: โดยปกติแล้ว แนะนำให้ล้างเวอร์ชันก่อนหน้า อย่างไรก็ตาม ไฟล์ปรับแต่งใดๆ จะสูญหายไป",
 
   // Window Names
-  "ui.window.setting.name": "การตั้งค่า",
+  "ui.window.settings.name": "การตั้งค่า",
   "ui.window.profiles.name": "โปรไฟล์",
   "ui.window.profile_naming.name": "ชื่อโปรไฟล์",
 

--- a/Stardrop/i18n/tr.json
+++ b/Stardrop/i18n/tr.json
@@ -111,7 +111,7 @@
 	"ui.message.confirm_mod_update_method": "{0} modunun eski bir sürümü tespit edildi. Eski sürümü temizlemek ister misin?\n\nNot: Eski sürümleri temizlemek genellikle önerilir, ancak her türlü yapılandırma dosyası kaybolacaktır.",
 
 	// Window Names
-	"ui.window.setting.name": "Ayarlar",
+	"ui.window.settings.name": "Ayarlar",
 	"ui.window.profiles.name": "Profiller",
 	"ui.window.profile_naming.name": "Profil İsmi",
 

--- a/Stardrop/i18n/uk.json
+++ b/Stardrop/i18n/uk.json
@@ -190,7 +190,7 @@
   "ui.message.succeeded_nexus_install": "Успішно встановлено наступний мод через Nexusmods:\n\n{0}",
 
   // Window Names
-  "ui.window.setting.name": "Налаштування",
+  "ui.window.settings.name": "Налаштування",
   "ui.window.profiles.name": "Профілі",
   "ui.window.profile_naming.name": "Назва профілю",
   "ui.window.nexus_login.name": "Персональний API ключ Nexusmods",

--- a/Stardrop/i18n/zh.json
+++ b/Stardrop/i18n/zh.json
@@ -116,7 +116,7 @@
   "ui.message.confirm_mod_update_method": "检测到先前版本的 {0}。是否要清除先前的安装？\n\n注意：通常建议清除先前版本，但任何配置都会丢失。",
 
   // Window Names
-  "ui.window.setting.name": "设置",
+  "ui.window.settings.name": "设置",
   "ui.window.profiles.name": "配置文件",
   "ui.window.profile_naming.name": "配置文件名称",
 


### PR DESCRIPTION
Unifies `ui.window.settings` and `ui.window.setting` translation keys into a single key `ui.window.settings`. I believe this was an unintentional typo. It fixes showing title for settings window which was referring to `ui.window.settings.name` which does not exist:
```
SettingsWindow.axaml:
10: Title="{i18n:Translate ui.window.settings.name}"
```

Tested on Linux with English, not tested on MacOS and Windows.