### PR TITLE
Add multiple mod archives from folder

### DIFF
--- a/Stardrop/Models/Settings.cs
+++ b/Stardrop/Models/Settings.cs
@@ -13,6 +13,7 @@ namespace Stardrop.Models
         public string SMAPIFolderPath { get; set; }
         public string ModFolderPath { get; set; }
         public string ModInstallPath { get; set; }
+        public string FolderForModsToAddPath { get; set; }
         public bool IgnoreHiddenFolders { get; set; } = true;
         public bool EnableProfileSpecificModConfigs { get; set; }
         public bool ShouldWriteToModConfigs { get; set; }

--- a/Stardrop/ViewModels/SettingsWindowViewModel.cs
+++ b/Stardrop/ViewModels/SettingsWindowViewModel.cs
@@ -10,6 +10,10 @@ namespace Stardrop.ViewModels
         public string SMAPIPath { get { return Program.settings.SMAPIFolderPath; } set { Program.settings.SMAPIFolderPath = value; Pathing.SetSmapiPath(Program.settings.SMAPIFolderPath, String.IsNullOrEmpty(Program.settings.ModFolderPath)); } }
         public string ModFolderPath { get { return Program.settings.ModFolderPath; } set { Program.settings.ModFolderPath = value; Pathing.SetModPath(Program.settings.ModFolderPath); } }
         public string ModInstallPath { get { return Program.settings.ModInstallPath; } set { Program.settings.ModInstallPath = value; } }
+        public string FolderForModsToAddPath {
+            get => Program.settings.FolderForModsToAddPath;
+            set => Program.settings.FolderForModsToAddPath = value;
+        }
         public bool IgnoreHiddenFolders { get { return Program.settings.IgnoreHiddenFolders; } set { Program.settings.IgnoreHiddenFolders = value; } }
         public bool IsAskingBeforeAcceptingNXM { get { return Program.settings.IsAskingBeforeAcceptingNXM; } set { Program.settings.IsAskingBeforeAcceptingNXM = value; } }
         public bool EnableProfileSpecificModConfigs { get { return Program.settings.EnableProfileSpecificModConfigs; } set { Program.settings.EnableProfileSpecificModConfigs = value; } }
@@ -19,6 +23,7 @@ namespace Stardrop.ViewModels
         public string ToolTip_SMAPI { get; set; }
         public string ToolTip_ModFolder { get; set; }
         public string ToolTip_ModInstall { get; set; }
+        public string ToolTip_FolderForModsToAdd { get; set; }
         public string ToolTip_Theme { get; set; }
         public string ToolTip_Language { get; set; }
         public string ToolTip_IgnoreHiddenFolders { get; set; }
@@ -42,6 +47,8 @@ namespace Stardrop.ViewModels
                 ToolTip_SMAPI = Program.translation.Get("ui.settings_window.tooltips.smapi");
                 ToolTip_ModFolder = Program.translation.Get("ui.settings_window.tooltips.mod_folder_path");
                 ToolTip_ModInstall = Program.translation.Get("ui.settings_window.tooltips.mod_install_path");
+                ToolTip_FolderForModsToAdd =
+                    Program.translation.Get("ui.settings_window.tooltips.folder_for_mods_to_add_path");
                 ToolTip_Theme = Program.translation.Get("ui.settings_window.tooltips.theme");
                 ToolTip_Language = Program.translation.Get("ui.settings_window.tooltips.language");
                 ToolTip_IgnoreHiddenFolders = Program.translation.Get("ui.settings_window.tooltips.ignore_hidden_folders");

--- a/Stardrop/Views/MainWindow.axaml
+++ b/Stardrop/Views/MainWindow.axaml
@@ -285,6 +285,7 @@
 			<NativeMenuItem Header="{i18n:Translate ui.main_window.menu_headers.file}">
 				<NativeMenu>
 					<NativeMenuItem Header="{i18n:Translate ui.main_window.menu_items.add_mod}" Click="AddMod_Click" />
+					<NativeMenuItem Header="{i18n:Translate ui.main_window.menu_items.add_mods_from_folder}" Click="AddModsFromFolder_Click" />
 					<NativeMenuItemSeparator/>
 					<NativeMenuItem Header="{i18n:Translate ui.main_window.menu_items.start_smapi}" Click="Smapi_Click" />
 					<NativeMenuItemSeparator/>
@@ -303,6 +304,8 @@
 				<NativeMenu>
 					<NativeMenuItem Header="{i18n:Translate ui.main_window.menu_items.refresh_mod_list}" Click="ModListRefresh_Click" />
 					<NativeMenuItem Header="{i18n:Translate ui.main_window.menu_items.check_for_mod_updates}" Click="ModUpdateCheck_Click" />
+					<NativeMenuItemSeparator/>
+					<NativeMenuItem Header="{i18n:Translate ui.main_window.menu_items.update_profile}" Click="UpdateProfile_Click" />
 					<NativeMenuItemSeparator/>
 					<NativeMenuItem Header="{i18n:Translate ui.main_window.menu_items.enable_all_mods}" Click="EnableAllMods_Click" />
 					<NativeMenuItem Header="{i18n:Translate ui.main_window.menu_items.disable_all_mods}" Click="DisableAllMods_Click" />
@@ -342,6 +345,7 @@
 				<Image Name="menuIcon" Source="/Assets/icon.ico" Stretch="None"/>
 				<MenuItem Header="{i18n:Translate ui.main_window.menu_headers.file}" Margin="-10 0 0 0" Classes="Bar">
 					<MenuItem Header="{i18n:Translate ui.main_window.menu_items.add_mod}" Click="AddMod_Click" Classes="Bar"/>
+					<MenuItem Header="{i18n:Translate ui.main_window.menu_items.add_mods_from_folder}" Click="AddModsFromFolder_Click" Classes="Bar"/>
 					<Separator/>
 					<MenuItem Header="{i18n:Translate ui.main_window.menu_items.start_smapi}" Click="Smapi_Click" Classes="Bar"/>
 					<Separator/>
@@ -356,6 +360,8 @@
 				<MenuItem Header="{i18n:Translate ui.main_window.menu_headers.tools}" Margin="-10 0 0 0" Classes="Bar">
 					<MenuItem Header="{i18n:Translate ui.main_window.menu_items.refresh_mod_list}" Click="ModListRefresh_Click" Classes="Bar"/>
 					<MenuItem Header="{i18n:Translate ui.main_window.menu_items.check_for_mod_updates}" Click="ModUpdateCheck_Click" Classes="Bar"/>
+					<Separator/>
+					<MenuItem Header="{i18n:Translate ui.main_window.menu_items.update_profile}" Click="UpdateProfile_Click" Classes="Bar"/>
 					<Separator/>
 					<MenuItem Header="{i18n:Translate ui.main_window.menu_items.enable_all_mods}" Click="EnableAllMods_Click" Classes="Bar"/>
 					<MenuItem Header="{i18n:Translate ui.main_window.menu_items.disable_all_mods}" Click="DisableAllMods_Click" Classes="Bar"/>

--- a/Stardrop/Views/MainWindow.axaml
+++ b/Stardrop/Views/MainWindow.axaml
@@ -419,6 +419,7 @@
 			</Grid>
 		</DockPanel>
 		<DockPanel Name="toolBar" Grid.Row="2"  Grid.Column="1">
+			<Button Name="saveChangesButton" Content="{i18n:Translate ui.main_window.buttons.save_changes}" VerticalAlignment="Center" Margin="5 0 0 0" Foreground="{DynamicResource ThemeForegroundBrush}" Background="Transparent" BorderBrush="{DynamicResource HighlightBrush}"/>
 			<TextBlock Text="{Binding SmapiVersion}" Foreground="{DynamicResource ThemeForegroundBrush}" VerticalAlignment="Bottom" HorizontalAlignment="Right" Margin="30 0 0 0" />
 			<Button Name="smapiButton" IsEnabled="{Binding !IsLocked}" Content="/Assets/icon.ico" Background="Transparent" HorizontalAlignment="Right" Width="60" Height="40" VerticalAlignment="Center"  Margin="0 0 10 0">
 				<Panel>

--- a/Stardrop/Views/MainWindow.axaml.cs
+++ b/Stardrop/Views/MainWindow.axaml.cs
@@ -1908,11 +1908,10 @@ namespace Stardrop.Views
 
         private async Task<List<Mod>> AddMods(string[]? filePaths)
         {
+            await HandleModListRefresh();
+
             var addedMods = new List<Mod>();
-            if (filePaths is null)
-            {
-                return addedMods;
-            }
+            if (filePaths is null) { return addedMods; }
 
             // Export zip to the default mods folder
             foreach (string fileFullName in filePaths)

--- a/Stardrop/Views/MainWindow.axaml.cs
+++ b/Stardrop/Views/MainWindow.axaml.cs
@@ -2037,7 +2037,7 @@ namespace Stardrop.Views
                                     }
                                 }
                                 SetLockState(false);
-                                addedMods.Add(new Mod(manifest, new FileInfo(manifestFolderPath), manifest.UniqueID, manifest.Version, manifest.Name, manifest.Description, manifest.Author));
+                                addedMods.Add(new Mod(manifest, new FileInfo(Path.Join(installPath, manifestFolderPath)), manifest.UniqueID, manifest.Version, manifest.Name, manifest.Description, manifest.Author));
                             }
                             else
                             {

--- a/Stardrop/Views/MainWindow.axaml.cs
+++ b/Stardrop/Views/MainWindow.axaml.cs
@@ -128,6 +128,7 @@ namespace Stardrop.Views
             this.FindControl<Button>("exitButton").Click += Exit_Click;
             this.FindControl<Button>("editProfilesButton").Click += EditProfilesButton_Click;
             this.FindControl<Button>("saveConfigsToProfile").Click += SaveConfigButton_Click;
+            this.FindControl<Button>("saveChangesButton").Click += SaveChanges_Click;
             this.FindControl<Button>("smapiButton").Click += Smapi_Click;
             this.FindControl<CheckBox>("showUpdatableMods").Click += ShowUpdatableModsButton_Click;
             this.FindControl<Button>("nexusModsButton").Click += NexusModsButton_Click;
@@ -778,14 +779,24 @@ namespace Stardrop.Views
         }
 
         // Menu related click events
-        private void Smapi_Click(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
+        private async void SaveChanges_Click(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
         {
-            StartSMAPI();
+            await SaveChanges();
         }
 
-        private void Smapi_Click(object? sender, EventArgs e)
+        private async void SaveChanges_Click(object? sender, EventArgs e)
         {
-            StartSMAPI();
+            await SaveChanges();
+        }
+
+        private async void Smapi_Click(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
+        {
+            await StartSMAPI();
+        }
+
+        private async void Smapi_Click(object? sender, EventArgs e)
+        {
+            await StartSMAPI();
         }
 
         private async void AddMod_Click(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
@@ -957,7 +968,7 @@ namespace Stardrop.Views
         }
 
         // End of events
-        private async Task StartSMAPI()
+        private async Task SaveChanges()
         {
             UpdateProfile(GetCurrentProfile());
 
@@ -994,6 +1005,11 @@ namespace Stardrop.Views
                 // Write the settings cache
                 File.WriteAllText(Pathing.GetSettingsPath(), JsonSerializer.Serialize(Program.settings, new JsonSerializerOptions() { WriteIndented = true }));
             }
+        }
+
+        private async Task StartSMAPI()
+        {
+            await SaveChanges();
 
             using (Process smapi = Process.Start(SMAPI.GetPrepareProcess(false)))
             {
@@ -1953,7 +1969,7 @@ namespace Stardrop.Views
                                                 alwaysAskToDelete = false;
                                             }
 
-                                            // Delete old vesrion
+                                            // Delete old version.
                                             var targetDirectory = new DirectoryInfo(mod.ModFileInfo.DirectoryName);
                                             if (targetDirectory is not null && targetDirectory.Exists)
                                             {

--- a/Stardrop/Views/MainWindow.axaml.cs
+++ b/Stardrop/Views/MainWindow.axaml.cs
@@ -730,8 +730,6 @@ namespace Stardrop.Views
                     }
                 }
             }
-
-            UpdateProfile(GetCurrentProfile());
         }
 
         private async void EditProfilesButton_Click(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
@@ -840,6 +838,16 @@ namespace Stardrop.Views
             await HandleModUpdateCheck();
         }
 
+        private async void UpdateProfile_Click(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
+        {
+            UpdateProfile(GetCurrentProfile());
+        }
+
+        private async void UpdateProfile_Click(object? sender, EventArgs e)
+        {
+            UpdateProfile(GetCurrentProfile());
+        }
+
         private async void StardropUpdate_Click(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
         {
             await HandleStardropUpdateCheck(true);
@@ -868,6 +876,16 @@ namespace Stardrop.Views
         private async void ModListRefresh_Click(object? sender, EventArgs e)
         {
             await HandleModListRefresh();
+        }
+
+        private async void AddModsFromFolder_Click(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
+        {
+            await HandleAddModsFromFolder();
+        }
+
+        private async void AddModsFromFolder_Click(object? sender, EventArgs e)
+        {
+            await HandleAddModsFromFolder();
         }
 
         private async void NexusModBulkInstall_Click(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
@@ -941,6 +959,8 @@ namespace Stardrop.Views
         // End of events
         private async Task StartSMAPI()
         {
+            UpdateProfile(GetCurrentProfile());
+
             Program.helper.Log($"Starting SMAPI at path: {Program.settings.SMAPIFolderPath}", Helper.Status.Debug);
             if (await ValidateSMAPIPath() is false)
             {
@@ -955,7 +975,7 @@ namespace Stardrop.Views
             var profile = this.FindControl<ComboBox>("profileComboBox").SelectedItem as Profile;
             if (profile is null)
             {
-                CreateWarningWindow(Program.translation.Get("ui.warning.unable_to_determine_profile"), Program.translation.Get("internal.ok"));
+                await CreateWarningWindow(Program.translation.Get("ui.warning.unable_to_determine_profile"), Program.translation.Get("internal.ok"));
                 Program.helper.Log($"Unable to determine selected profile, SMAPI will not be started!", Helper.Status.Alert);
                 return;
             }
@@ -1414,6 +1434,22 @@ namespace Stardrop.Views
 
             // Hide the required mods
             _viewModel.HideRequiredMods();
+        }
+
+
+        private bool isArchive(string file) {
+            return
+                file.EndsWith(".zip", StringComparison.OrdinalIgnoreCase) ||
+                file.EndsWith(".7z", StringComparison.OrdinalIgnoreCase) ||
+                file.EndsWith(".rar", StringComparison.OrdinalIgnoreCase);
+        }
+
+        private async Task HandleAddModsFromFolder()
+        {
+            var mod_folder_path = Program.settings.FolderForModsToAddPath;
+            var files = Directory.EnumerateFiles(mod_folder_path, "*", SearchOption.TopDirectoryOnly)
+                .Where(file => isArchive(file)).ToArray();
+            await AddMods(files);
         }
 
         internal async Task<bool> ProcessNXMLink(string? apiKey, NXM nxmLink)
@@ -1893,7 +1929,7 @@ namespace Stardrop.Views
                             bool isUpdate = false;
                             if (manifest is not null)
                             {
-                                string installPath = Program.settings.ModInstallPath;
+                                var installPath = Program.settings.ModInstallPath;
                                 if (_viewModel.Mods.FirstOrDefault(m => m.UniqueId.Equals(manifest.UniqueID, StringComparison.OrdinalIgnoreCase)) is Mod mod && mod is not null && mod.ModFileInfo.Directory is not null)
                                 {
                                     if (manifest.DeleteOldVersion is false && alwaysAskToDelete is true)
@@ -1944,6 +1980,7 @@ namespace Stardrop.Views
                                 SetLockState(true, String.Format(isUpdate ? Program.translation.Get("ui.warning.mod_updating") : Program.translation.Get("ui.warning.mod_installing"), manifest.Name));
 
                                 Program.helper.Log($"Install path for mod {manifest.UniqueID}:{installPath}");
+                                string outputPath;
                                 var manifestFolderPath = manifestPath.Replace("manifest.json", String.Empty, StringComparison.OrdinalIgnoreCase);
                                 foreach (var entry in archive.Entries.Where(e => e.Key.StartsWith(manifestFolderPath)))
                                 {
@@ -1951,7 +1988,7 @@ namespace Stardrop.Views
                                     {
                                         continue;
                                     }
-                                    var outputPath = Path.Combine(installPath, manifestFolderPath, String.IsNullOrEmpty(manifestFolderPath) ? entry.Key : Path.GetRelativePath(manifestFolderPath, entry.Key));
+                                    outputPath = Path.Combine(installPath, manifestFolderPath, String.IsNullOrEmpty(manifestFolderPath) ? entry.Key : Path.GetRelativePath(manifestFolderPath, entry.Key));
 
                                     if (String.IsNullOrEmpty(manifestFolderPath) is false)
                                     {
@@ -1983,9 +2020,8 @@ namespace Stardrop.Views
                                         await Task.Run(() => entry.WriteToFile(outputPath, new ExtractionOptions() { ExtractFullPath = false, Overwrite = true }));
                                     }
                                 }
-
                                 SetLockState(false);
-                                addedMods.Add(new Mod(manifest, null, manifest.UniqueID, manifest.Version, manifest.Name, manifest.Description, manifest.Author));
+                                addedMods.Add(new Mod(manifest, new FileInfo(manifestFolderPath), manifest.UniqueID, manifest.Version, manifest.Name, manifest.Description, manifest.Author));
                             }
                             else
                             {

--- a/Stardrop/Views/SettingsWindow.axaml
+++ b/Stardrop/Views/SettingsWindow.axaml
@@ -190,6 +190,9 @@
 			<TextBlock Text="{i18n:Translate ui.settings_window.labels.mod_install}" Margin="0 10 0 0" VerticalAlignment="Center" HorizontalAlignment="Left" Foreground="{DynamicResource ThemeForegroundBrush}" />
 			<TextBox Name="modInstallPathBox" Text="{Binding ModInstallPath}" ToolTip.Tip="{Binding ToolTip_ModInstall}" Margin="10 10 0 0" Height="10" Width="350" BorderBrush="{DynamicResource HighlightBrush}" HorizontalAlignment="Left"/>
 			<Button Name="modInstallButton" Margin="360 -32 0 0" i:Attached.Icon="mdi-folder" Foreground="{DynamicResource ThemeForegroundBrush}" Background="Transparent" HorizontalAlignment="Left" />
+			<TextBlock Text="{i18n:Translate ui.settings_window.labels.folder_for_mods_to_add_path}" Margin="0 10 0 0" VerticalAlignment="Center" HorizontalAlignment="Left" Foreground="{DynamicResource ThemeForegroundBrush}" />
+			<TextBox Name="FolderForModsToAddPathBox" Text="{Binding FolderForModsToAddPath}" ToolTip.Tip="{Binding ToolTip_FolderForModsToAdd}" Margin="10 10 0 0" Height="10" Width="350" BorderBrush="{DynamicResource HighlightBrush}" HorizontalAlignment="Left"/>
+			<Button Name="FolderForModsToAddButton" Margin="360 -32 0 0" i:Attached.Icon="mdi-folder" Foreground="{DynamicResource ThemeForegroundBrush}" Background="Transparent" HorizontalAlignment="Left" />
 		</StackPanel>
 
 		<StackPanel Grid.Row="2" Margin="10 10 0 0">

--- a/Stardrop/i18n/default.json
+++ b/Stardrop/i18n/default.json
@@ -1,6 +1,7 @@
 {
   // Main Window - Menu Items
   "ui.main_window.menu_items.add_mod": "Add Mod",
+  "ui.main_window.menu_items.add_mods_from_folder": "Add Mods From Folder",
   "ui.main_window.menu_items.start_smapi": "Start SMAPI",
   "ui.main_window.menu_items.exit": "Exit",
   "ui.main_window.menu_items.settings": "Settings",
@@ -8,6 +9,7 @@
   "ui.main_window.menu_items.smapi_log_file": "SMAPI Log File",
   "ui.main_window.menu_items.refresh_mod_list": "Refresh Mod List",
   "ui.main_window.menu_items.check_for_mod_updates": "Check for Mod Updates",
+  "ui.main_window.menu_items.update_profile": "Update Profile",
   "ui.main_window.menu_items.enable_all_mods": "Enable All Mods",
   "ui.main_window.menu_items.disable_all_mods": "Disable All Mods",
   "ui.main_window.menu_items.check_for_stardrop_update": "Check for Stardrop Update",
@@ -81,6 +83,7 @@
   "ui.settings_window.labels.smapi_path": "SMAPI Path",
   "ui.settings_window.labels.mod_path": "Mod Folder Path",
   "ui.settings_window.labels.mod_install": "Stardrop Installed Mods Path",
+  "ui.settings_window.labels.folder_for_mods_to_add_path": "Mods to Add Folder Path",
   "ui.settings_window.labels.themes": "Themes",
   "ui.settings_window.labels.languages": "Languages",
   "ui.settings_window.labels.miscellaneous": "Miscellaneous",
@@ -98,6 +101,7 @@
   "ui.settings_window.tooltips.smapi": "The file path of StardewModdingAPI",
   "ui.settings_window.tooltips.mod_folder_path": "The folder path of the mod folder",
   "ui.settings_window.tooltips.mod_install_path": "The folder path which Stardrop will place newly installed mods. Must be under the folder given in \"Mod Folder Path\"",
+  "ui.settings_window.tooltips.folder_for_mods_to_add_path": "The folder path which Stardrop will extract mod archives from.",
   "ui.settings_window.tooltips.theme": "The current theme of Stardrop",
   "ui.settings_window.tooltips.language": "The current language of Stardrop",
   "ui.settings_window.tooltips.ignore_hidden_folders": "If checked, Stardrop will ignore any mods which have a parent folder that start with \".\"",

--- a/Stardrop/i18n/default.json
+++ b/Stardrop/i18n/default.json
@@ -63,6 +63,7 @@
 
   // Main Window - Buttons
   "ui.main_window.buttons.save_configs": "Save Configs",
+  "ui.main_window.buttons.save_changes": "Save Changes",
   "ui.main_window.buttons.hide_disabled_mods": "Hide Disabled Mods",
   "ui.main_window.buttons.show_updatable_mods": "Show Updatable Mods",
 


### PR DESCRIPTION
This PR adds a convenience function to add (+ update) multiple mods at once by just clicking one button. It allows for specifying one folder where to find mods (the folder is searched for archive files).

I find this workflow very pleasant to use:
1. Click to all `Update available` notifications to open mod websites.
2. Download all mods to a single folder. (Your favourite browser will remember which folder you last used for NexusMods website (and for GitHub and other websites) which makes it especially easy to update everything very swiftly.)
3. Click one button to update all.
4. (In another PR) Since you can disable the “delete previous folder” warning, you can immediately update all of your updatable mods, and add new mods you have found, all without any unnecessary clicking.

I have 3k mods installed. Each refresh of mod list or update of profiles takes several seconds. Therefore, it is crucial that each install of a new mod doe **not** refresh the mod list or update the profile. Refresh is performed only after all bulk-installed mods are installed.

Furthermore, each click on any checkbox in mod list takes several seconds, shifts the mod list view (when the mod list refreshes). For Stardrop to be usable for such quantity of mods, updating after every checkbox click is undesirable. I added a button to save changes which updates the profile, refreshes the mod list, etc. It is also automatically run when starting SMAPI, as it already was previously. For this reason, when a user clicks the checkbox, nothing happens until they click either run SMAPI, save changes, or click one of the menu save/update something options. If this is an undesirable design approach in your eyes, a settings option "Save changes manually" with tooltip description "Do not save changes until changes are confirmed." or something similar can be added, too.  

If you find this feature interesting, translations (for now just copy-paste the English description, I presume) for other languages need to be added. Tested on Linux, not tested on Windows and MacOS.