### PR TITLE
Add settings option to always ask to delete mod files on update

### DIFF
--- a/Stardrop/Models/Settings.cs
+++ b/Stardrop/Models/Settings.cs
@@ -17,6 +17,10 @@ namespace Stardrop.Models
         public bool EnableProfileSpecificModConfigs { get; set; }
         public bool ShouldWriteToModConfigs { get; set; }
         public bool EnableModsOnAdd { get; set; }
+        /// <summary>
+        /// Whether to always ask before deleting a previous version of a mod when updating the mod.
+        /// </summary>
+        public bool AlwaysAskToDelete { get; set; } = true;
         public NexusServers PreferredNexusServer { get; set; } = NexusServers.NexusCDN;
         public bool IsAskingBeforeAcceptingNXM { get; set; } = true;
         public GameDetails GameDetails { get; set; }

--- a/Stardrop/ViewModels/SettingsWindowViewModel.cs
+++ b/Stardrop/ViewModels/SettingsWindowViewModel.cs
@@ -14,6 +14,7 @@ namespace Stardrop.ViewModels
         public bool IsAskingBeforeAcceptingNXM { get { return Program.settings.IsAskingBeforeAcceptingNXM; } set { Program.settings.IsAskingBeforeAcceptingNXM = value; } }
         public bool EnableProfileSpecificModConfigs { get { return Program.settings.EnableProfileSpecificModConfigs; } set { Program.settings.EnableProfileSpecificModConfigs = value; } }
         public bool EnableModsOnAdd { get { return Program.settings.EnableModsOnAdd; } set { Program.settings.EnableModsOnAdd = value; } }
+        public bool AlwaysAskToDelete { get { return Program.settings.AlwaysAskToDelete; } set { Program.settings.AlwaysAskToDelete = value; } }
 
         // Tooltips
         public string ToolTip_SMAPI { get; set; }

--- a/Stardrop/Views/MainWindow.axaml.cs
+++ b/Stardrop/Views/MainWindow.axaml.cs
@@ -1926,6 +1926,11 @@ namespace Stardrop.Views
                                             DeleteMod(mod);
                                         }
                                     }
+                                    else
+                                    {
+                                        // Delete old version
+                                        DeleteMod(mod);
+                                    }
 
                                     isUpdate = true;
                                     installPath = mod.ModFileInfo.Directory.FullName;

--- a/Stardrop/Views/MainWindow.axaml.cs
+++ b/Stardrop/Views/MainWindow.axaml.cs
@@ -483,11 +483,7 @@ namespace Stardrop.Views
                     if (await requestWindow.ShowDialog<bool>(this))
                     {
                         // Delete old vesrion
-                        var targetDirectory = new DirectoryInfo(mod.ModFileInfo.DirectoryName);
-                        if (targetDirectory is not null)
-                        {
-                            targetDirectory.Delete(true);
-                        }
+                        DeleteMod(mod);
 
                         hasDeletedAMod = true;
                     }
@@ -1854,6 +1850,15 @@ namespace Stardrop.Views
             return downloadedFilePath;
         }
 
+        private void DeleteMod(Mod mod)
+        {
+            var targetDirectory = new DirectoryInfo(mod.ModFileInfo.DirectoryName);
+            if (targetDirectory is not null && targetDirectory.Exists)
+            {
+                targetDirectory.Delete(true);
+            }
+        }
+
         private async Task<List<Mod>> AddMods(string[]? filePaths)
         {
             var addedMods = new List<Mod>();
@@ -1917,12 +1922,8 @@ namespace Stardrop.Views
                                                 alwaysAskToDelete = false;
                                             }
 
-                                            // Delete old vesrion
-                                            var targetDirectory = new DirectoryInfo(mod.ModFileInfo.DirectoryName);
-                                            if (targetDirectory is not null && targetDirectory.Exists)
-                                            {
-                                                targetDirectory.Delete(true);
-                                            }
+                                            // Delete old version
+                                            DeleteMod(mod);
                                         }
                                     }
 

--- a/Stardrop/Views/MainWindow.axaml.cs
+++ b/Stardrop/Views/MainWindow.axaml.cs
@@ -1884,7 +1884,7 @@ namespace Stardrop.Views
                             continue;
                         }
 
-                        bool alwaysAskToDelete = true;
+                        bool alwaysAskToDelete = Program.settings.AlwaysAskToDelete;
                         foreach (var manifestPath in pathToManifests.Keys)
                         {
                             var manifest = pathToManifests[manifestPath];

--- a/Stardrop/Views/SettingsWindow.axaml
+++ b/Stardrop/Views/SettingsWindow.axaml
@@ -214,6 +214,7 @@
 			<CheckBox Name="ignoreHiddenFoldersCheckbox" IsChecked="{Binding IgnoreHiddenFolders}" Content="{i18n:Translate ui.settings_window.buttons.ignore_hidden_folders}" ToolTip.Tip="{Binding ToolTip_IgnoreHiddenFolders}" VerticalAlignment="Center" HorizontalAlignment="Left" Foreground="{DynamicResource ThemeForegroundBrush}" />
 			<CheckBox Name="enableProfileSpecificModConfigsCheckbox" IsChecked="{Binding EnableProfileSpecificModConfigs}" Content="{i18n:Translate ui.settings_window.buttons.enable_profile_specific_mod_configs}" ToolTip.Tip="{Binding ToolTip_EnableProfileSpecificModConfigs}" VerticalAlignment="Center" HorizontalAlignment="Left" Foreground="{DynamicResource ThemeForegroundBrush}" />
 			<CheckBox Name="enableModsOnAdd" IsChecked="{Binding EnableModsOnAdd}" Content="{i18n:Translate ui.settings_window.buttons.enable_mods_on_add}" ToolTip.Tip="{Binding ToolTip_EnableModsOnAdd}" VerticalAlignment="Center" HorizontalAlignment="Left" Foreground="{DynamicResource ThemeForegroundBrush}" />
+			<CheckBox Name="alwaysAskToDelete" IsChecked="{Binding AlwaysAskToDelete}" Content="{i18n:Translate ui.settings_window.buttons.always_ask_to_delete}" ToolTip.Tip="{Binding ToolTip_AlwaysAskToDelete}" VerticalAlignment="Center" HorizontalAlignment="Left" Foreground="{DynamicResource ThemeForegroundBrush}" />
 		</StackPanel>
 
 		<DockPanel Grid.Row="5" Grid.Column="1" Margin="0 0 0 0">

--- a/Stardrop/i18n/default.json
+++ b/Stardrop/i18n/default.json
@@ -91,6 +91,7 @@
   "ui.settings_window.buttons.ignore_hidden_folders": "Ignore Hidden Folders",
   "ui.settings_window.buttons.enable_profile_specific_mod_configs": "Enable Profile Specific Mod Configs",
   "ui.settings_window.buttons.enable_mods_on_add": "Automatically Enable Mods On Install",
+  "ui.settings_window.buttons.always_ask_to_delete": "Always Ask To Delete Mod Files On Update",
   "ui.settings_window.buttons.always_ask_for_NXM_installs": "Always Ask Before Installing NXM Files",
   "ui.settings_window.buttons.register_nxm_association": "Register NXM Association",
 
@@ -105,6 +106,7 @@
   "ui.settings_window.tooltips.always_ask_nxm_files": "If checked, Stardrop will always ask before installing a mod from www.nexusmods.com via NXM",
   "ui.settings_window.tooltips.enable_profile_specific_configs": "If checked, Stardrop will save and restore config.json files from mods when swapping profiles",
   "ui.settings_window.tooltips.enable_mods_on_add": "If checked, Stardrop will automatically enable newly added or updated mods",
+  "ui.settings_window.tooltips.always_ask_to_delete": "If checked, Stardrop will always ask whether to delete mod files when updating the mod",
   "ui.settings_window.tooltips.preferred_server": "Sets your preferred server to use when downloading from Nexus Mods",
   "ui.settings_window.tooltips.save_changes": "Save Changes",
   "ui.settings_window.tooltips.cancel_changes": "Cancel",


### PR DESCRIPTION
This PR adds an option to disable the warning to always ask to delete previously installed mod files.

Deleting previously installed mod files is de-facto the standard for mod updates and should be preventively done all the time. Therefore, the user has an option to set this in the settings: They will never have to click `Yes to all` for another mod.

This PR pairs well with #146. There is a big difference between clicking one button to update all and updating 50 mods one by one with manually click `Yes to all` for all updated mods.

If you find this feature useful, translations for other languages needs to be added (for now just the English version copy-pasted everywhere). Tested on Linux, not tested on Windows and MacOS.