### PR TITLE
Save changes only on demand

### DIFF
--- a/Stardrop/Models/Settings.cs
+++ b/Stardrop/Models/Settings.cs
@@ -21,6 +21,7 @@ namespace Stardrop.Models
         /// Whether to always ask before deleting a previous version of a mod when updating the mod.
         /// </summary>
         public bool AlwaysAskToDelete { get; set; } = true;
+        public bool ShouldAutomaticallySaveProfileChanges { get; set; } = true;
         public NexusServers PreferredNexusServer { get; set; } = NexusServers.NexusCDN;
         public bool IsAskingBeforeAcceptingNXM { get; set; } = true;
         public GameDetails GameDetails { get; set; }

--- a/Stardrop/ViewModels/MainWindowViewModel.cs
+++ b/Stardrop/ViewModels/MainWindowViewModel.cs
@@ -71,6 +71,8 @@ namespace Stardrop.ViewModels
         public string NexusLimits { get { return _nexusLimits; } set { this.RaiseAndSetIfChanged(ref _nexusLimits, value); } }
         private string _smapiVersion;
         public string SmapiVersion { get { return String.IsNullOrEmpty(_smapiVersion) ? Program.translation.Get("ui.main_window.labels.unknown_SMAPI") : $"v{_smapiVersion}"; } set { this.RaiseAndSetIfChanged(ref _smapiVersion, value); } }
+        public bool ShowSaveProfileChanges { get { return _showSaveProfileChanges; } set { this.RaiseAndSetIfChanged(ref _showSaveProfileChanges, value); } }
+        private bool _showSaveProfileChanges;
 
         public MainWindowViewModel(string modsFilePath, string version)
         {

--- a/Stardrop/ViewModels/SettingsWindowViewModel.cs
+++ b/Stardrop/ViewModels/SettingsWindowViewModel.cs
@@ -15,6 +15,7 @@ namespace Stardrop.ViewModels
         public bool EnableProfileSpecificModConfigs { get { return Program.settings.EnableProfileSpecificModConfigs; } set { Program.settings.EnableProfileSpecificModConfigs = value; } }
         public bool EnableModsOnAdd { get { return Program.settings.EnableModsOnAdd; } set { Program.settings.EnableModsOnAdd = value; } }
         public bool AlwaysAskToDelete { get { return Program.settings.AlwaysAskToDelete; } set { Program.settings.AlwaysAskToDelete = value; } }
+        public bool ShouldAutomaticallySaveProfileChanges { get { return Program.settings.ShouldAutomaticallySaveProfileChanges; } set { Program.settings.ShouldAutomaticallySaveProfileChanges = value; } }
 
         // Tooltips
         public string ToolTip_SMAPI { get; set; }
@@ -28,6 +29,7 @@ namespace Stardrop.ViewModels
         public string ToolTip_AlwaysAskNXMFiles { get; set; }
         public string ToolTip_EnableProfileSpecificModConfigs { get; set; }
         public string ToolTip_EnableModsOnAdd { get; set; }
+        public string ToolTip_ShouldAutomaticallySaveProfileChanges { get; set; }
         public string ToolTip_Save { get; set; }
         public string ToolTip_Cancel { get; set; }
 
@@ -51,6 +53,7 @@ namespace Stardrop.ViewModels
                 ToolTip_AlwaysAskNXMFiles = Program.translation.Get("ui.settings_window.tooltips.always_ask_nxm_files");
                 ToolTip_EnableProfileSpecificModConfigs = Program.translation.Get("ui.settings_window.tooltips.enable_profile_specific_configs");
                 ToolTip_EnableModsOnAdd = Program.translation.Get("ui.settings_window.tooltips.enable_mods_on_add");
+                ToolTip_ShouldAutomaticallySaveProfileChanges = Program.translation.Get("ui.settings_window.tooltips.automatically_save_profile_changes");
                 ToolTip_Save = Program.translation.Get("ui.settings_window.tooltips.save_changes");
                 ToolTip_Cancel = Program.translation.Get("ui.settings_window.tooltips.cancel_changes");
             }

--- a/Stardrop/Views/MainWindow.axaml
+++ b/Stardrop/Views/MainWindow.axaml
@@ -393,7 +393,7 @@
 			</ComboBox>
 			<Button Name="editProfilesButton" i:Attached.Icon="mdi-playlist-edit" VerticalAlignment="Center" Margin="5 0 0 0" Foreground="{DynamicResource ThemeForegroundBrush}" Background="Transparent" BorderBrush="{DynamicResource HighlightBrush}"/>
 			<Button Name="saveConfigsToProfile" Content="{i18n:Translate ui.main_window.buttons.save_configs}" VerticalAlignment="Center" Margin="5 0 0 0" Foreground="{DynamicResource ThemeForegroundBrush}" Background="Transparent" BorderBrush="{DynamicResource HighlightBrush}"/>
-			<Button Name="saveProfileChanges" Content="{i18n:Translate ui.main_window.buttons.save_profile}" VerticalAlignment="Center" Margin="5 0 0 0" Foreground="{DynamicResource ThemeForegroundBrush}" Background="Transparent" BorderBrush="{DynamicResource HighlightBrush}"/>
+			<Button Name="saveProfileChanges" IsVisible="{Binding ShowSaveProfileChanges}" Content="{i18n:Translate ui.main_window.buttons.save_profile}" VerticalAlignment="Center" Margin="5 0 0 0" Foreground="{DynamicResource ThemeForegroundBrush}" Background="Transparent" BorderBrush="{DynamicResource HighlightBrush}"/>
 			<Grid>
 				<Grid.ColumnDefinitions>
 					<ColumnDefinition Width="Auto" />

--- a/Stardrop/Views/MainWindow.axaml
+++ b/Stardrop/Views/MainWindow.axaml
@@ -304,6 +304,8 @@
 					<NativeMenuItem Header="{i18n:Translate ui.main_window.menu_items.refresh_mod_list}" Click="ModListRefresh_Click" />
 					<NativeMenuItem Header="{i18n:Translate ui.main_window.menu_items.check_for_mod_updates}" Click="ModUpdateCheck_Click" />
 					<NativeMenuItemSeparator/>
+					<NativeMenuItem Header="{i18n:Translate ui.main_window.menu_items.update_profile}" Click="UpdateProfile_Click" />
+					<NativeMenuItemSeparator/>
 					<NativeMenuItem Header="{i18n:Translate ui.main_window.menu_items.enable_all_mods}" Click="EnableAllMods_Click" />
 					<NativeMenuItem Header="{i18n:Translate ui.main_window.menu_items.disable_all_mods}" Click="DisableAllMods_Click" />
 					<NativeMenuItemSeparator/>
@@ -356,6 +358,8 @@
 				<MenuItem Header="{i18n:Translate ui.main_window.menu_headers.tools}" Margin="-10 0 0 0" Classes="Bar">
 					<MenuItem Header="{i18n:Translate ui.main_window.menu_items.refresh_mod_list}" Click="ModListRefresh_Click" Classes="Bar"/>
 					<MenuItem Header="{i18n:Translate ui.main_window.menu_items.check_for_mod_updates}" Click="ModUpdateCheck_Click" Classes="Bar"/>
+					<Separator/>
+					<MenuItem Header="{i18n:Translate ui.main_window.menu_items.update_profile}" Click="UpdateProfile_Click" Classes="Bar"/>
 					<Separator/>
 					<MenuItem Header="{i18n:Translate ui.main_window.menu_items.enable_all_mods}" Click="EnableAllMods_Click" Classes="Bar"/>
 					<MenuItem Header="{i18n:Translate ui.main_window.menu_items.disable_all_mods}" Click="DisableAllMods_Click" Classes="Bar"/>

--- a/Stardrop/Views/MainWindow.axaml
+++ b/Stardrop/Views/MainWindow.axaml
@@ -393,6 +393,7 @@
 			</ComboBox>
 			<Button Name="editProfilesButton" i:Attached.Icon="mdi-playlist-edit" VerticalAlignment="Center" Margin="5 0 0 0" Foreground="{DynamicResource ThemeForegroundBrush}" Background="Transparent" BorderBrush="{DynamicResource HighlightBrush}"/>
 			<Button Name="saveConfigsToProfile" Content="{i18n:Translate ui.main_window.buttons.save_configs}" VerticalAlignment="Center" Margin="5 0 0 0" Foreground="{DynamicResource ThemeForegroundBrush}" Background="Transparent" BorderBrush="{DynamicResource HighlightBrush}"/>
+			<Button Name="saveProfileChanges" Content="{i18n:Translate ui.main_window.buttons.save_profile}" VerticalAlignment="Center" Margin="5 0 0 0" Foreground="{DynamicResource ThemeForegroundBrush}" Background="Transparent" BorderBrush="{DynamicResource HighlightBrush}"/>
 			<Grid>
 				<Grid.ColumnDefinitions>
 					<ColumnDefinition Width="Auto" />
@@ -413,7 +414,6 @@
 			</Grid>
 		</DockPanel>
 		<DockPanel Name="toolBar" Grid.Row="2"  Grid.Column="1">
-			<Button Name="saveChangesButton" Content="{i18n:Translate ui.main_window.buttons.save_changes}" VerticalAlignment="Center" Margin="5 0 0 0" Foreground="{DynamicResource ThemeForegroundBrush}" Background="Transparent" BorderBrush="{DynamicResource HighlightBrush}"/>
 			<TextBlock Text="{Binding SmapiVersion}" Foreground="{DynamicResource ThemeForegroundBrush}" VerticalAlignment="Bottom" HorizontalAlignment="Right" Margin="30 0 0 0" />
 			<Button Name="smapiButton" IsEnabled="{Binding !IsLocked}" Content="/Assets/icon.ico" Background="Transparent" HorizontalAlignment="Right" Width="60" Height="40" VerticalAlignment="Center"  Margin="0 0 10 0">
 				<Panel>

--- a/Stardrop/Views/MainWindow.axaml
+++ b/Stardrop/Views/MainWindow.axaml
@@ -304,8 +304,6 @@
 					<NativeMenuItem Header="{i18n:Translate ui.main_window.menu_items.refresh_mod_list}" Click="ModListRefresh_Click" />
 					<NativeMenuItem Header="{i18n:Translate ui.main_window.menu_items.check_for_mod_updates}" Click="ModUpdateCheck_Click" />
 					<NativeMenuItemSeparator/>
-					<NativeMenuItem Header="{i18n:Translate ui.main_window.menu_items.update_profile}" Click="UpdateProfile_Click" />
-					<NativeMenuItemSeparator/>
 					<NativeMenuItem Header="{i18n:Translate ui.main_window.menu_items.enable_all_mods}" Click="EnableAllMods_Click" />
 					<NativeMenuItem Header="{i18n:Translate ui.main_window.menu_items.disable_all_mods}" Click="DisableAllMods_Click" />
 					<NativeMenuItemSeparator/>
@@ -358,8 +356,6 @@
 				<MenuItem Header="{i18n:Translate ui.main_window.menu_headers.tools}" Margin="-10 0 0 0" Classes="Bar">
 					<MenuItem Header="{i18n:Translate ui.main_window.menu_items.refresh_mod_list}" Click="ModListRefresh_Click" Classes="Bar"/>
 					<MenuItem Header="{i18n:Translate ui.main_window.menu_items.check_for_mod_updates}" Click="ModUpdateCheck_Click" Classes="Bar"/>
-					<Separator/>
-					<MenuItem Header="{i18n:Translate ui.main_window.menu_items.update_profile}" Click="UpdateProfile_Click" Classes="Bar"/>
 					<Separator/>
 					<MenuItem Header="{i18n:Translate ui.main_window.menu_items.enable_all_mods}" Click="EnableAllMods_Click" Classes="Bar"/>
 					<MenuItem Header="{i18n:Translate ui.main_window.menu_items.disable_all_mods}" Click="DisableAllMods_Click" Classes="Bar"/>

--- a/Stardrop/Views/MainWindow.axaml
+++ b/Stardrop/Views/MainWindow.axaml
@@ -417,6 +417,7 @@
 			</Grid>
 		</DockPanel>
 		<DockPanel Name="toolBar" Grid.Row="2"  Grid.Column="1">
+			<Button Name="saveChangesButton" Content="{i18n:Translate ui.main_window.buttons.save_changes}" VerticalAlignment="Center" Margin="5 0 0 0" Foreground="{DynamicResource ThemeForegroundBrush}" Background="Transparent" BorderBrush="{DynamicResource HighlightBrush}"/>
 			<TextBlock Text="{Binding SmapiVersion}" Foreground="{DynamicResource ThemeForegroundBrush}" VerticalAlignment="Bottom" HorizontalAlignment="Right" Margin="30 0 0 0" />
 			<Button Name="smapiButton" IsEnabled="{Binding !IsLocked}" Content="/Assets/icon.ico" Background="Transparent" HorizontalAlignment="Right" Width="60" Height="40" VerticalAlignment="Center"  Margin="0 0 10 0">
 				<Panel>

--- a/Stardrop/Views/MainWindow.axaml.cs
+++ b/Stardrop/Views/MainWindow.axaml.cs
@@ -845,16 +845,6 @@ namespace Stardrop.Views
             await HandleModUpdateCheck();
         }
 
-        private async void UpdateProfile_Click(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
-        {
-            UpdateProfile(GetCurrentProfile());
-        }
-
-        private async void UpdateProfile_Click(object? sender, EventArgs e)
-        {
-            UpdateProfile(GetCurrentProfile());
-        }
-
         private async void StardropUpdate_Click(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
         {
             await HandleStardropUpdateCheck(true);

--- a/Stardrop/Views/MainWindow.axaml.cs
+++ b/Stardrop/Views/MainWindow.axaml.cs
@@ -1887,6 +1887,8 @@ namespace Stardrop.Views
 
         private async Task<List<Mod>> AddMods(string[]? filePaths)
         {
+            await HandleModListRefresh();
+
             var addedMods = new List<Mod>();
             if (filePaths is null)
             {

--- a/Stardrop/Views/MainWindow.axaml.cs
+++ b/Stardrop/Views/MainWindow.axaml.cs
@@ -727,6 +727,15 @@ namespace Stardrop.Views
                     }
                 }
             }
+
+            if (Program.settings.ShouldAutomaticallySaveProfileChanges)
+            {
+                UpdateProfile(GetCurrentProfile());
+            }
+            else
+            {
+                _viewModel.ShowSaveProfileChanges = true;
+            }
         }
 
         private async void EditProfilesButton_Click(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
@@ -947,6 +956,8 @@ namespace Stardrop.Views
         private async Task SaveChanges()
         {
             UpdateProfile(GetCurrentProfile());
+
+            _viewModel.ShowSaveProfileChanges = false;
         }
 
         private async Task StartSMAPI()
@@ -1030,6 +1041,8 @@ namespace Stardrop.Views
             if (await editorWindow.ShowDialog<bool>(this))
             {
                 await HandleModListRefresh();
+
+                _viewModel.ShowSaveProfileChanges = !Program.settings.ShouldAutomaticallySaveProfileChanges;
             }
         }
 

--- a/Stardrop/Views/MainWindow.axaml.cs
+++ b/Stardrop/Views/MainWindow.axaml.cs
@@ -1968,7 +1968,6 @@ namespace Stardrop.Views
                                 SetLockState(true, String.Format(isUpdate ? Program.translation.Get("ui.warning.mod_updating") : Program.translation.Get("ui.warning.mod_installing"), manifest.Name));
 
                                 Program.helper.Log($"Install path for mod {manifest.UniqueID}:{installPath}");
-                                string outputPath;
                                 var manifestFolderPath = manifestPath.Replace("manifest.json", String.Empty, StringComparison.OrdinalIgnoreCase);
                                 foreach (var entry in archive.Entries.Where(e => e.Key.StartsWith(manifestFolderPath)))
                                 {
@@ -1976,7 +1975,7 @@ namespace Stardrop.Views
                                     {
                                         continue;
                                     }
-                                    outputPath = Path.Combine(installPath, manifestFolderPath, String.IsNullOrEmpty(manifestFolderPath) ? entry.Key : Path.GetRelativePath(manifestFolderPath, entry.Key));
+                                    var outputPath = Path.Combine(installPath, manifestFolderPath, String.IsNullOrEmpty(manifestFolderPath) ? entry.Key : Path.GetRelativePath(manifestFolderPath, entry.Key));
 
                                     if (String.IsNullOrEmpty(manifestFolderPath) is false)
                                     {

--- a/Stardrop/Views/MainWindow.axaml.cs
+++ b/Stardrop/Views/MainWindow.axaml.cs
@@ -836,6 +836,16 @@ namespace Stardrop.Views
             await HandleModUpdateCheck();
         }
 
+        private async void UpdateProfile_Click(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
+        {
+            UpdateProfile(GetCurrentProfile());
+        }
+
+        private async void UpdateProfile_Click(object? sender, EventArgs e)
+        {
+            UpdateProfile(GetCurrentProfile());
+        }
+
         private async void StardropUpdate_Click(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
         {
             await HandleStardropUpdateCheck(true);

--- a/Stardrop/Views/MainWindow.axaml.cs
+++ b/Stardrop/Views/MainWindow.axaml.cs
@@ -2000,9 +2000,8 @@ namespace Stardrop.Views
                                         await Task.Run(() => entry.WriteToFile(outputPath, new ExtractionOptions() { ExtractFullPath = false, Overwrite = true }));
                                     }
                                 }
-
                                 SetLockState(false);
-                                addedMods.Add(new Mod(manifest, null, manifest.UniqueID, manifest.Version, manifest.Name, manifest.Description, manifest.Author));
+                                addedMods.Add(new Mod(manifest, new FileInfo(Path.Join(installPath, manifestFolderPath)), manifest.UniqueID, manifest.Version, manifest.Name, manifest.Description, manifest.Author));
                             }
                             else
                             {

--- a/Stardrop/Views/MainWindow.axaml.cs
+++ b/Stardrop/Views/MainWindow.axaml.cs
@@ -128,7 +128,7 @@ namespace Stardrop.Views
             this.FindControl<Button>("exitButton").Click += Exit_Click;
             this.FindControl<Button>("editProfilesButton").Click += EditProfilesButton_Click;
             this.FindControl<Button>("saveConfigsToProfile").Click += SaveConfigButton_Click;
-            this.FindControl<Button>("saveChangesButton").Click += SaveChanges_Click;
+            this.FindControl<Button>("saveProfileChanges").Click += SaveProfileChanges_Click;
             this.FindControl<Button>("smapiButton").Click += Smapi_Click;
             this.FindControl<CheckBox>("showUpdatableMods").Click += ShowUpdatableModsButton_Click;
             this.FindControl<Button>("nexusModsButton").Click += NexusModsButton_Click;
@@ -775,12 +775,12 @@ namespace Stardrop.Views
         }
 
         // Menu related click events
-        private async void SaveChanges_Click(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
+        private async void SaveProfileChanges_Click(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
         {
             await SaveChanges();
         }
 
-        private async void SaveChanges_Click(object? sender, EventArgs e)
+        private async void SaveProfileChanges_Click(object? sender, EventArgs e)
         {
             await SaveChanges();
         }

--- a/Stardrop/Views/MainWindow.axaml.cs
+++ b/Stardrop/Views/MainWindow.axaml.cs
@@ -947,6 +947,11 @@ namespace Stardrop.Views
         private async Task SaveChanges()
         {
             UpdateProfile(GetCurrentProfile());
+        }
+
+        private async Task StartSMAPI()
+        {
+            await SaveChanges();
 
             Program.helper.Log($"Starting SMAPI at path: {Program.settings.SMAPIFolderPath}", Helper.Status.Debug);
             if (await ValidateSMAPIPath() is false)
@@ -981,11 +986,6 @@ namespace Stardrop.Views
                 // Write the settings cache
                 File.WriteAllText(Pathing.GetSettingsPath(), JsonSerializer.Serialize(Program.settings, new JsonSerializerOptions() { WriteIndented = true }));
             }
-        }
-
-        private async Task StartSMAPI()
-        {
-            await SaveChanges();
 
             using (Process smapi = Process.Start(SMAPI.GetPrepareProcess(false)))
             {

--- a/Stardrop/Views/MainWindow.axaml.cs
+++ b/Stardrop/Views/MainWindow.axaml.cs
@@ -726,8 +726,6 @@ namespace Stardrop.Views
                     }
                 }
             }
-
-            UpdateProfile(GetCurrentProfile());
         }
 
         private async void EditProfilesButton_Click(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
@@ -947,6 +945,8 @@ namespace Stardrop.Views
         // End of events
         private async Task StartSMAPI()
         {
+            UpdateProfile(GetCurrentProfile());
+
             Program.helper.Log($"Starting SMAPI at path: {Program.settings.SMAPIFolderPath}", Helper.Status.Debug);
             if (await ValidateSMAPIPath() is false)
             {

--- a/Stardrop/Views/MainWindow.axaml.cs
+++ b/Stardrop/Views/MainWindow.axaml.cs
@@ -961,7 +961,7 @@ namespace Stardrop.Views
             var profile = this.FindControl<ComboBox>("profileComboBox").SelectedItem as Profile;
             if (profile is null)
             {
-                CreateWarningWindow(Program.translation.Get("ui.warning.unable_to_determine_profile"), Program.translation.Get("internal.ok"));
+                await CreateWarningWindow(Program.translation.Get("ui.warning.unable_to_determine_profile"), Program.translation.Get("internal.ok"));
                 Program.helper.Log($"Unable to determine selected profile, SMAPI will not be started!", Helper.Status.Alert);
                 return;
             }
@@ -1908,7 +1908,7 @@ namespace Stardrop.Views
                             bool isUpdate = false;
                             if (manifest is not null)
                             {
-                                string installPath = Program.settings.ModInstallPath;
+                                var installPath = Program.settings.ModInstallPath;
                                 if (_viewModel.Mods.FirstOrDefault(m => m.UniqueId.Equals(manifest.UniqueID, StringComparison.OrdinalIgnoreCase)) is Mod mod && mod is not null && mod.ModFileInfo.Directory is not null)
                                 {
                                     if (manifest.DeleteOldVersion is false && alwaysAskToDelete is true)
@@ -1960,6 +1960,7 @@ namespace Stardrop.Views
                                 SetLockState(true, String.Format(isUpdate ? Program.translation.Get("ui.warning.mod_updating") : Program.translation.Get("ui.warning.mod_installing"), manifest.Name));
 
                                 Program.helper.Log($"Install path for mod {manifest.UniqueID}:{installPath}");
+                                string outputPath;
                                 var manifestFolderPath = manifestPath.Replace("manifest.json", String.Empty, StringComparison.OrdinalIgnoreCase);
                                 foreach (var entry in archive.Entries.Where(e => e.Key.StartsWith(manifestFolderPath)))
                                 {
@@ -1967,7 +1968,7 @@ namespace Stardrop.Views
                                     {
                                         continue;
                                     }
-                                    var outputPath = Path.Combine(installPath, manifestFolderPath, String.IsNullOrEmpty(manifestFolderPath) ? entry.Key : Path.GetRelativePath(manifestFolderPath, entry.Key));
+                                    outputPath = Path.Combine(installPath, manifestFolderPath, String.IsNullOrEmpty(manifestFolderPath) ? entry.Key : Path.GetRelativePath(manifestFolderPath, entry.Key));
 
                                     if (String.IsNullOrEmpty(manifestFolderPath) is false)
                                     {

--- a/Stardrop/Views/MainWindow.axaml.cs
+++ b/Stardrop/Views/MainWindow.axaml.cs
@@ -128,6 +128,7 @@ namespace Stardrop.Views
             this.FindControl<Button>("exitButton").Click += Exit_Click;
             this.FindControl<Button>("editProfilesButton").Click += EditProfilesButton_Click;
             this.FindControl<Button>("saveConfigsToProfile").Click += SaveConfigButton_Click;
+            this.FindControl<Button>("saveChangesButton").Click += SaveChanges_Click;
             this.FindControl<Button>("smapiButton").Click += Smapi_Click;
             this.FindControl<CheckBox>("showUpdatableMods").Click += ShowUpdatableModsButton_Click;
             this.FindControl<Button>("nexusModsButton").Click += NexusModsButton_Click;
@@ -774,14 +775,24 @@ namespace Stardrop.Views
         }
 
         // Menu related click events
-        private void Smapi_Click(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
+        private async void SaveChanges_Click(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
         {
-            StartSMAPI();
+            await SaveChanges();
         }
 
-        private void Smapi_Click(object? sender, EventArgs e)
+        private async void SaveChanges_Click(object? sender, EventArgs e)
         {
-            StartSMAPI();
+            await SaveChanges();
+        }
+
+        private async void Smapi_Click(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
+        {
+            await StartSMAPI();
+        }
+
+        private async void Smapi_Click(object? sender, EventArgs e)
+        {
+            await StartSMAPI();
         }
 
         private async void AddMod_Click(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
@@ -943,7 +954,7 @@ namespace Stardrop.Views
         }
 
         // End of events
-        private async Task StartSMAPI()
+        private async Task SaveChanges()
         {
             UpdateProfile(GetCurrentProfile());
 
@@ -980,6 +991,11 @@ namespace Stardrop.Views
                 // Write the settings cache
                 File.WriteAllText(Pathing.GetSettingsPath(), JsonSerializer.Serialize(Program.settings, new JsonSerializerOptions() { WriteIndented = true }));
             }
+        }
+
+        private async Task StartSMAPI()
+        {
+            await SaveChanges();
 
             using (Process smapi = Process.Start(SMAPI.GetPrepareProcess(false)))
             {

--- a/Stardrop/Views/SettingsWindow.axaml
+++ b/Stardrop/Views/SettingsWindow.axaml
@@ -215,6 +215,7 @@
 			<CheckBox Name="enableProfileSpecificModConfigsCheckbox" IsChecked="{Binding EnableProfileSpecificModConfigs}" Content="{i18n:Translate ui.settings_window.buttons.enable_profile_specific_mod_configs}" ToolTip.Tip="{Binding ToolTip_EnableProfileSpecificModConfigs}" VerticalAlignment="Center" HorizontalAlignment="Left" Foreground="{DynamicResource ThemeForegroundBrush}" />
 			<CheckBox Name="enableModsOnAdd" IsChecked="{Binding EnableModsOnAdd}" Content="{i18n:Translate ui.settings_window.buttons.enable_mods_on_add}" ToolTip.Tip="{Binding ToolTip_EnableModsOnAdd}" VerticalAlignment="Center" HorizontalAlignment="Left" Foreground="{DynamicResource ThemeForegroundBrush}" />
 			<CheckBox Name="alwaysAskToDelete" IsChecked="{Binding AlwaysAskToDelete}" Content="{i18n:Translate ui.settings_window.buttons.always_ask_to_delete}" ToolTip.Tip="{Binding ToolTip_AlwaysAskToDelete}" VerticalAlignment="Center" HorizontalAlignment="Left" Foreground="{DynamicResource ThemeForegroundBrush}" />
+			<CheckBox Name="automaticallySaveProfileChanges" IsChecked="{Binding ShouldAutomaticallySaveProfileChanges}" Content="{i18n:Translate ui.settings_window.buttons.automatically_save_profile_changes}" ToolTip.Tip="{Binding ToolTip_ShouldAutomaticallySaveProfileChanges}" VerticalAlignment="Center" HorizontalAlignment="Left" Foreground="{DynamicResource ThemeForegroundBrush}" />
 		</StackPanel>
 
 		<DockPanel Grid.Row="5" Grid.Column="1" Margin="0 0 0 0">

--- a/Stardrop/i18n/default.json
+++ b/Stardrop/i18n/default.json
@@ -93,6 +93,7 @@
   "ui.settings_window.buttons.enable_profile_specific_mod_configs": "Enable Profile Specific Mod Configs",
   "ui.settings_window.buttons.enable_mods_on_add": "Automatically Enable Mods On Install",
   "ui.settings_window.buttons.always_ask_to_delete": "Always Ask To Delete Mod Files On Update",
+  "ui.settings_window.buttons.automatically_save_profile_changes": "Automatically Save Profile Changes",
   "ui.settings_window.buttons.always_ask_for_NXM_installs": "Always Ask Before Installing NXM Files",
   "ui.settings_window.buttons.register_nxm_association": "Register NXM Association",
 
@@ -108,6 +109,7 @@
   "ui.settings_window.tooltips.enable_profile_specific_configs": "If checked, Stardrop will save and restore config.json files from mods when swapping profiles",
   "ui.settings_window.tooltips.enable_mods_on_add": "If checked, Stardrop will automatically enable newly added or updated mods",
   "ui.settings_window.tooltips.always_ask_to_delete": "If checked, Stardrop will always ask whether to delete mod files when updating the mod",
+  "ui.settings_window.tooltips.automatically_save_profile_changes": "If checked, Stardrop will automatically save changes made to the profile",
   "ui.settings_window.tooltips.preferred_server": "Sets your preferred server to use when downloading from Nexus Mods",
   "ui.settings_window.tooltips.save_changes": "Save Changes",
   "ui.settings_window.tooltips.cancel_changes": "Cancel",

--- a/Stardrop/i18n/default.json
+++ b/Stardrop/i18n/default.json
@@ -8,6 +8,7 @@
   "ui.main_window.menu_items.smapi_log_file": "SMAPI Log File",
   "ui.main_window.menu_items.refresh_mod_list": "Refresh Mod List",
   "ui.main_window.menu_items.check_for_mod_updates": "Check for Mod Updates",
+  "ui.main_window.menu_items.update_profile": "Update Profile",
   "ui.main_window.menu_items.enable_all_mods": "Enable All Mods",
   "ui.main_window.menu_items.disable_all_mods": "Disable All Mods",
   "ui.main_window.menu_items.check_for_stardrop_update": "Check for Stardrop Update",

--- a/Stardrop/i18n/default.json
+++ b/Stardrop/i18n/default.json
@@ -62,6 +62,7 @@
 
   // Main Window - Buttons
   "ui.main_window.buttons.save_configs": "Save Configs",
+  "ui.main_window.buttons.save_changes": "Save Changes",
   "ui.main_window.buttons.hide_disabled_mods": "Hide Disabled Mods",
   "ui.main_window.buttons.show_updatable_mods": "Show Updatable Mods",
 

--- a/Stardrop/i18n/default.json
+++ b/Stardrop/i18n/default.json
@@ -8,7 +8,6 @@
   "ui.main_window.menu_items.smapi_log_file": "SMAPI Log File",
   "ui.main_window.menu_items.refresh_mod_list": "Refresh Mod List",
   "ui.main_window.menu_items.check_for_mod_updates": "Check for Mod Updates",
-  "ui.main_window.menu_items.update_profile": "Update Profile",
   "ui.main_window.menu_items.enable_all_mods": "Enable All Mods",
   "ui.main_window.menu_items.disable_all_mods": "Disable All Mods",
   "ui.main_window.menu_items.check_for_stardrop_update": "Check for Stardrop Update",

--- a/Stardrop/i18n/default.json
+++ b/Stardrop/i18n/default.json
@@ -61,7 +61,7 @@
 
   // Main Window - Buttons
   "ui.main_window.buttons.save_configs": "Save Configs",
-  "ui.main_window.buttons.save_changes": "Save Changes",
+  "ui.main_window.buttons.save_profile": "Save Profile",
   "ui.main_window.buttons.hide_disabled_mods": "Hide Disabled Mods",
   "ui.main_window.buttons.show_updatable_mods": "Show Updatable Mods",
 


### PR DESCRIPTION
First part of reworked #146. This PR disables automatic refresh of mod list and update of the user profile after any enable mod checkbox is clicked. Now, the changes made by the user are saved after clicking a new save changes button, starting SMAPI, or manually updating the profile from the dropdown menu.

Adding multiple mods through `AddMods()` refreshes the mod list only after all mods are installed, that is, at the end of the function, and not after every mod.

A button to save changes which updates the profile, refreshes the mod list, etc. has been added. It is also automatically run when starting SMAPI, as it already was previously. For this reason, when a user clicks the checkbox, nothing happens until they click either run SMAPI, save changes, or click one of the menu save/update something options.

If this is an undesirable design approach in your eyes, a settings option "Save changes manually" with tooltip description "Do not save changes until changes are confirmed." or something similar can be added, too.

Translations for other languages need to be added. Tested on Linux, not tested on Windows and MacOS.