### PR TITLE
Add multiple mods from file picker

### DIFF
--- a/Stardrop/Views/MainWindow.axaml
+++ b/Stardrop/Views/MainWindow.axaml
@@ -284,7 +284,7 @@
 		<NativeMenu>
 			<NativeMenuItem Header="{i18n:Translate ui.main_window.menu_headers.file}">
 				<NativeMenu>
-					<NativeMenuItem Header="{i18n:Translate ui.main_window.menu_items.add_mod}" Click="AddMod_Click" />
+					<NativeMenuItem Header="{i18n:Translate ui.main_window.menu_items.add_mods}" Click="AddMod_Click" />
 					<NativeMenuItemSeparator/>
 					<NativeMenuItem Header="{i18n:Translate ui.main_window.menu_items.start_smapi}" Click="Smapi_Click" />
 					<NativeMenuItemSeparator/>
@@ -341,7 +341,7 @@
 			<Menu Name="mainMenu" IsVisible="{Binding ShowMainMenu}" HorizontalAlignment="Left" KeyboardNavigation.TabNavigation="None">
 				<Image Name="menuIcon" Source="/Assets/icon.ico" Stretch="None"/>
 				<MenuItem Header="{i18n:Translate ui.main_window.menu_headers.file}" Margin="-10 0 0 0" Classes="Bar">
-					<MenuItem Header="{i18n:Translate ui.main_window.menu_items.add_mod}" Click="AddMod_Click" Classes="Bar"/>
+					<MenuItem Header="{i18n:Translate ui.main_window.menu_items.add_mods}" Click="AddMod_Click" Classes="Bar"/>
 					<Separator/>
 					<MenuItem Header="{i18n:Translate ui.main_window.menu_items.start_smapi}" Click="Smapi_Click" Classes="Bar"/>
 					<Separator/>

--- a/Stardrop/Views/MainWindow.axaml.cs
+++ b/Stardrop/Views/MainWindow.axaml.cs
@@ -995,7 +995,7 @@ namespace Stardrop.Views
 
             OpenFileDialog dialog = new OpenFileDialog();
             dialog.Filters.Add(new FileDialogFilter() { Name = "Mod Archive (*.zip, *.7z, *.rar)", Extensions = { "zip", "7z", "rar" } });
-            dialog.AllowMultiple = false;
+            dialog.AllowMultiple = true;
 
             var addedMods = await AddMods(await dialog.ShowAsync(this));
 

--- a/Stardrop/i18n/default.json
+++ b/Stardrop/i18n/default.json
@@ -1,6 +1,7 @@
 {
   // Main Window - Menu Items
   "ui.main_window.menu_items.add_mod": "Add Mod",
+  "ui.main_window.menu_items.add_mods": "Add Mods",
   "ui.main_window.menu_items.start_smapi": "Start SMAPI",
   "ui.main_window.menu_items.exit": "Exit",
   "ui.main_window.menu_items.settings": "Settings",

--- a/Stardrop/i18n/default.json
+++ b/Stardrop/i18n/default.json
@@ -1,6 +1,6 @@
 {
   // Main Window - Menu Items
-  "ui.main_window.menu_items.add_mod": "Add Mods",
+  "ui.main_window.menu_items.add_mod": "Add Mod",
   "ui.main_window.menu_items.start_smapi": "Start SMAPI",
   "ui.main_window.menu_items.exit": "Exit",
   "ui.main_window.menu_items.settings": "Settings",

--- a/Stardrop/i18n/default.json
+++ b/Stardrop/i18n/default.json
@@ -1,6 +1,6 @@
 {
   // Main Window - Menu Items
-  "ui.main_window.menu_items.add_mod": "Add Mod",
+  "ui.main_window.menu_items.add_mod": "Add Mods",
   "ui.main_window.menu_items.start_smapi": "Start SMAPI",
   "ui.main_window.menu_items.exit": "Exit",
   "ui.main_window.menu_items.settings": "Settings",


### PR DESCRIPTION
This PR allows picking multiple mods in `File -> Add Mod`. Since adding multiple mods is an option now, it also changes the text to `Add Mods` instead of `Add Mod`.