### PR TITLE
Show whole mod group or author's mods

### DIFF
--- a/Stardrop/Views/MainWindow.axaml
+++ b/Stardrop/Views/MainWindow.axaml
@@ -441,6 +441,7 @@
 						<MenuItem Header="{i18n:Translate ui.main_window.menu_items.context.filters}">
 							<MenuItem Header="{i18n:Translate ui.main_window.menu_items.context.show_whole_mod_group}" Click="ModGridMenuRow_ShowWholeModGroup" />
 							<MenuItem Header="{i18n:Translate ui.main_window.menu_items.context.show_authors_mods}" Click="ModGridMenuRow_ShowAuthorsMods" />
+							<MenuItem Header="{i18n:Translate ui.main_window.menu_items.context.clear_filter}" Click="ModGridMenuRow_ClearFilter" />
 						</MenuItem>
 						<MenuItem Header="{Binding ChangeStateText}" Click="ModGridMenuRow_ChangeState" />
 						<MenuItem Header="{i18n:Translate ui.main_window.menu_items.context.delete}" Click="ModGridMenuRow_Delete" />

--- a/Stardrop/Views/MainWindow.axaml
+++ b/Stardrop/Views/MainWindow.axaml
@@ -438,6 +438,8 @@
 					<ContextMenu x:Key="GridRowContextMenu">
 						<MenuItem Header="{i18n:Translate ui.main_window.menu_items.context.open_containing_folder}" Click="ModGridMenuRow_OpenFolderPath" />
 						<MenuItem Header="{i18n:Translate ui.main_window.menu_items.context.open_mod_page}" Click="ModGridMenuRow_OpenModPage" IsVisible="{Binding ModPageUri, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" />
+						<MenuItem Header="{i18n:Translate ui.main_window.menu_items.context.show_whole_mod_group}" Click="ModGridMenuRow_ShowWholeModGroup" />
+						<MenuItem Header="{i18n:Translate ui.main_window.menu_items.context.show_authors_mods}" Click="ModGridMenuRow_ShowAuthorsMods" />
 						<MenuItem Header="{Binding ChangeStateText}" Click="ModGridMenuRow_ChangeState" />
 						<MenuItem Header="{i18n:Translate ui.main_window.menu_items.context.delete}" Click="ModGridMenuRow_Delete" />
 						<MenuItem Header="{i18n:Translate ui.main_window.menu_items.context.cancel}" />

--- a/Stardrop/Views/MainWindow.axaml
+++ b/Stardrop/Views/MainWindow.axaml
@@ -564,9 +564,9 @@
 			<TextBox Name="searchBox" Watermark="{i18n:Translate ui.main_window.labels.filter}" Height="10" Width="250" BorderBrush="{DynamicResource HighlightBrush}" HorizontalAlignment="Left"/>
 			<ComboBox x:Name="searchFilterColumnBox" Margin="5 2 0 0" Background="{DynamicResource ThemeBackgroundBrush}" Foreground="{DynamicResource ThemeForegroundBrush}" FontWeight="Bold" BorderBrush="{DynamicResource HighlightBrush}" SelectedIndex="0" Width="150">
 				<ComboBoxItem Content="{i18n:Translate ui.main_window.combobox.mod_name}" />
+				<ComboBoxItem Content="{i18n:Translate ui.main_window.combobox.group}" />
 				<ComboBoxItem Content="{i18n:Translate ui.main_window.combobox.author}" />
 				<ComboBoxItem Content="{i18n:Translate ui.main_window.combobox.requirements}" />
-				<ComboBoxItem Content="{i18n:Translate ui.main_window.combobox.group}" />
 			</ComboBox>
 			<StackPanel Orientation="Horizontal" Margin="10 0 10 0">
 				<Separator Width="1" Height="15" Background="{DynamicResource HighlightBrush}" />

--- a/Stardrop/Views/MainWindow.axaml
+++ b/Stardrop/Views/MainWindow.axaml
@@ -438,8 +438,10 @@
 					<ContextMenu x:Key="GridRowContextMenu">
 						<MenuItem Header="{i18n:Translate ui.main_window.menu_items.context.open_containing_folder}" Click="ModGridMenuRow_OpenFolderPath" />
 						<MenuItem Header="{i18n:Translate ui.main_window.menu_items.context.open_mod_page}" Click="ModGridMenuRow_OpenModPage" IsVisible="{Binding ModPageUri, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" />
-						<MenuItem Header="{i18n:Translate ui.main_window.menu_items.context.show_whole_mod_group}" Click="ModGridMenuRow_ShowWholeModGroup" />
-						<MenuItem Header="{i18n:Translate ui.main_window.menu_items.context.show_authors_mods}" Click="ModGridMenuRow_ShowAuthorsMods" />
+						<MenuItem Header="{i18n:Translate ui.main_window.menu_items.context.filters}">
+							<MenuItem Header="{i18n:Translate ui.main_window.menu_items.context.show_whole_mod_group}" Click="ModGridMenuRow_ShowWholeModGroup" />
+							<MenuItem Header="{i18n:Translate ui.main_window.menu_items.context.show_authors_mods}" Click="ModGridMenuRow_ShowAuthorsMods" />
+						</MenuItem>
 						<MenuItem Header="{Binding ChangeStateText}" Click="ModGridMenuRow_ChangeState" />
 						<MenuItem Header="{i18n:Translate ui.main_window.menu_items.context.delete}" Click="ModGridMenuRow_Delete" />
 						<MenuItem Header="{i18n:Translate ui.main_window.menu_items.context.cancel}" />

--- a/Stardrop/Views/MainWindow.axaml
+++ b/Stardrop/Views/MainWindow.axaml
@@ -565,9 +565,9 @@
 		<DockPanel Name="filterBar" Grid.Row="4" Grid.Column="0" Margin="7 0 0 5">
 			<TextBox Name="searchBox" Watermark="{i18n:Translate ui.main_window.labels.filter}" Height="10" Width="250" BorderBrush="{DynamicResource HighlightBrush}" HorizontalAlignment="Left"/>
 			<ComboBox x:Name="searchFilterColumnBox" Margin="5 2 0 0" Background="{DynamicResource ThemeBackgroundBrush}" Foreground="{DynamicResource ThemeForegroundBrush}" FontWeight="Bold" BorderBrush="{DynamicResource HighlightBrush}" SelectedIndex="0" Width="150">
+				<ComboBoxItem Content="{i18n:Translate ui.main_window.combobox.author}" />
 				<ComboBoxItem Content="{i18n:Translate ui.main_window.combobox.mod_name}" />
 				<ComboBoxItem Content="{i18n:Translate ui.main_window.combobox.group}" />
-				<ComboBoxItem Content="{i18n:Translate ui.main_window.combobox.author}" />
 				<ComboBoxItem Content="{i18n:Translate ui.main_window.combobox.requirements}" />
 			</ComboBox>
 			<StackPanel Orientation="Horizontal" Margin="10 0 10 0">

--- a/Stardrop/Views/MainWindow.axaml.cs
+++ b/Stardrop/Views/MainWindow.axaml.cs
@@ -454,6 +454,26 @@ namespace Stardrop.Views
             _viewModel.OpenBrowser(selectedMod.ModPageUri);
         }
 
+        private void ModGridMenuRow_ShowWholeModGroup(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
+        {
+            var selectedMod = (sender as MenuItem)?.DataContext as Mod;
+            if (selectedMod is null) { return; }
+
+            this.FindControl<ComboBox>("searchFilterColumnBox").SelectedIndex = 1;
+            this.FindControl<TextBox>("searchBox").Text = selectedMod.Path;
+            _viewModel.FilterText = selectedMod.Path;
+        }
+
+        private void ModGridMenuRow_ShowAuthorsMods(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
+        {
+            var selectedMod = (sender as MenuItem)?.DataContext as Mod;
+            if (selectedMod is null) { return; }
+
+            this.FindControl<ComboBox>("searchFilterColumnBox").SelectedIndex = 2;
+            this.FindControl<TextBox>("searchBox").Text = selectedMod.Author;
+            _viewModel.FilterText = selectedMod.Author;
+        }
+
         private async void ModGridMenuRow_Delete(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
         {
             var modGrid = this.FindControl<DataGrid>("modGrid");

--- a/Stardrop/Views/MainWindow.axaml.cs
+++ b/Stardrop/Views/MainWindow.axaml.cs
@@ -457,9 +457,14 @@ namespace Stardrop.Views
         private void ModGridMenuRow_ShowWholeModGroup(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
         {
             var selectedMod = (sender as MenuItem)?.DataContext as Mod;
-            if (selectedMod is null) { return; }
+            if (selectedMod is null)
+            {
+                return;
+            }
 
-            this.FindControl<ComboBox>("searchFilterColumnBox").SelectedIndex = 1;
+            var searchFilterColumnBox = this.FindControl<ComboBox>("searchFilterColumnBox");
+            searchFilterColumnBox.SelectedItem = searchFilterColumnBox.Items.Cast<ComboBoxItem>().First(c => c.Content.ToString() == Program.translation.Get("ui.main_window.combobox.group"));
+            
             this.FindControl<TextBox>("searchBox").Text = selectedMod.Path;
             _viewModel.FilterText = selectedMod.Path;
         }
@@ -467,9 +472,14 @@ namespace Stardrop.Views
         private void ModGridMenuRow_ShowAuthorsMods(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
         {
             var selectedMod = (sender as MenuItem)?.DataContext as Mod;
-            if (selectedMod is null) { return; }
+            if (selectedMod is null)
+            {
+                return;
+            }
 
-            this.FindControl<ComboBox>("searchFilterColumnBox").SelectedIndex = 2;
+            var searchFilterColumnBox = this.FindControl<ComboBox>("searchFilterColumnBox");
+            searchFilterColumnBox.SelectedItem = searchFilterColumnBox.Items.Cast<ComboBoxItem>().First(c => c.Content.ToString() == Program.translation.Get("ui.main_window.combobox.author"));
+
             this.FindControl<TextBox>("searchBox").Text = selectedMod.Author;
             _viewModel.FilterText = selectedMod.Author;
         }

--- a/Stardrop/Views/MainWindow.axaml.cs
+++ b/Stardrop/Views/MainWindow.axaml.cs
@@ -482,6 +482,18 @@ namespace Stardrop.Views
 
             this.FindControl<TextBox>("searchBox").Text = selectedMod.Author;
             _viewModel.FilterText = selectedMod.Author;
+        }        
+
+        private void ModGridMenuRow_ClearFilter(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
+        {
+            var selectedMod = (sender as MenuItem)?.DataContext as Mod;
+            if (selectedMod is null)
+            {
+                return;
+            }
+
+            this.FindControl<TextBox>("searchBox").Text = String.Empty;
+            _viewModel.FilterText = String.Empty;
         }
 
         private async void ModGridMenuRow_Delete(object? sender, Avalonia.Interactivity.RoutedEventArgs e)

--- a/Stardrop/Views/MainWindow.axaml.cs
+++ b/Stardrop/Views/MainWindow.axaml.cs
@@ -137,7 +137,7 @@ namespace Stardrop.Views
 
             // Handle filtering by searchFilterColumnBox
             var searchFilterColumnBox = this.FindControl<ComboBox>("searchFilterColumnBox");
-            searchFilterColumnBox.SelectedIndex = 0;
+            searchFilterColumnBox.SelectedItem = searchFilterColumnBox.Items.Cast<ComboBoxItem>().First(c => c.Content.ToString() == Program.translation.Get("ui.main_window.combobox.mod_name"));
             searchFilterColumnBox.SelectionChanged += FilterComboBox_SelectionChanged;
 
             var disabledModFilterColumnBox = this.FindControl<ComboBox>("disabledModFilterColumnBox");

--- a/Stardrop/i18n/default.json
+++ b/Stardrop/i18n/default.json
@@ -26,6 +26,7 @@
   "ui.main_window.menu_items.context.show_whole_mod_group": "Show Whole Mod Group",
   "ui.main_window.menu_items.context.show_authors_mods": "Show Author's Mods",
   "ui.main_window.menu_items.context.filters": "Filters",
+  "ui.main_window.menu_items.context.clear_filter": "Clear",
   "ui.main_window.menu_items.context.delete": "Delete",
 
   // Main Window - Menu Headers

--- a/Stardrop/i18n/default.json
+++ b/Stardrop/i18n/default.json
@@ -23,6 +23,8 @@
   "ui.main_window.menu_items.context.cancel": "Cancel",
   "ui.main_window.menu_items.context.open_containing_folder": "Open Containing Folder",
   "ui.main_window.menu_items.context.open_mod_page": "Open Mod Page",
+  "ui.main_window.menu_items.context.show_whole_mod_group": "Show Whole Mod Group",
+  "ui.main_window.menu_items.context.show_authors_mods": "Show Author's Mods",
   "ui.main_window.menu_items.context.delete": "Delete",
 
   // Main Window - Menu Headers

--- a/Stardrop/i18n/default.json
+++ b/Stardrop/i18n/default.json
@@ -25,6 +25,7 @@
   "ui.main_window.menu_items.context.open_mod_page": "Open Mod Page",
   "ui.main_window.menu_items.context.show_whole_mod_group": "Show Whole Mod Group",
   "ui.main_window.menu_items.context.show_authors_mods": "Show Author's Mods",
+  "ui.main_window.menu_items.context.filters": "Filters",
   "ui.main_window.menu_items.context.delete": "Delete",
 
   // Main Window - Menu Headers


### PR DESCRIPTION
This PR adds two right click context menu items on selected mod:
1. show whole mod group, and
2. show author's mods.

Furthermore, the PR moves "Mod Group" filter option in the combobox to right after "Mod Name" since the two are closely related and should be next to each other (especially when the combobox is replaced with multi-select dropdown menu).

The functionality of the buttons is as follows:
1. This button sets the filter to show only mods in the same group as the selected mod.

2. This button sets the filter to show only mods by the same author as the author of the selected mod.

Tested on Linux, not tested on Windows or MacOS. Translations only for `default`, missing for other languages.