### PR TITLE
Ignore whitespaces in filter text search

### DIFF
--- a/Stardrop/ViewModels/MainWindowViewModel.cs
+++ b/Stardrop/ViewModels/MainWindowViewModel.cs
@@ -590,7 +590,8 @@ namespace Stardrop.ViewModels
 
             if (!String.IsNullOrEmpty(_filterText) && !String.IsNullOrEmpty(_columnFilter))
             {
-                if (_columnFilter == Program.translation.Get("ui.main_window.combobox.mod_name") && !mod.Name.Contains(_filterText, StringComparison.OrdinalIgnoreCase))
+                var filterTextNoWhitespace = _filterText.Replace(" ", String.Empty);
+                if (_columnFilter == Program.translation.Get("ui.main_window.combobox.mod_name") && !mod.Name.Replace(" ", String.Empty).Contains(filterTextNoWhitespace, StringComparison.OrdinalIgnoreCase))
                 {
                     return false;
                 }
@@ -600,18 +601,18 @@ namespace Stardrop.ViewModels
                     switch (Program.settings.ModGroupingMethod)
                     {
                         case ModGrouping.Folder:
-                            if (mod.Path.Contains(_filterText, StringComparison.OrdinalIgnoreCase) is false)
+                            if (mod.Path.Replace(" ", String.Empty).Contains(filterTextNoWhitespace, StringComparison.OrdinalIgnoreCase) is false)
                             {
                                 return false;
                             }
                             break;
                     }
                 }
-                else if (_columnFilter == Program.translation.Get("ui.main_window.combobox.author") && !mod.Author.Contains(_filterText, StringComparison.OrdinalIgnoreCase))
+                else if (_columnFilter == Program.translation.Get("ui.main_window.combobox.author") && !mod.Author.Replace(" ", String.Empty).Contains(filterTextNoWhitespace, StringComparison.OrdinalIgnoreCase))
                 {
                     return false;
                 }
-                else if (_columnFilter == Program.translation.Get("ui.main_window.combobox.requirements") && !mod.HardRequirements.Any(r => r.Name is null || r.Name.Contains(_filterText, StringComparison.OrdinalIgnoreCase)) && !mod.MissingRequirements.Any(r => r.Name is null || r.Name.Contains(_filterText, StringComparison.OrdinalIgnoreCase)))
+                else if (_columnFilter == Program.translation.Get("ui.main_window.combobox.requirements") && !mod.HardRequirements.Any(r => r.Name is null || r.Name.Replace(" ", String.Empty).Contains(filterTextNoWhitespace, StringComparison.OrdinalIgnoreCase)) && !mod.MissingRequirements.Any(r => r.Name is null || r.Name.Replace(" ", String.Empty).Contains(filterTextNoWhitespace, StringComparison.OrdinalIgnoreCase)))
                 {
                     return false;
                 }


### PR DESCRIPTION
This PR modifies the filter search function to ignore any spaces in the searched text, as well as the user-given search query.

I noticed that many mods have inconsistent names within a single mod (mod group), especially with different placement of spaces between the folder name (group name) and mod names within the folder. I constantly battle with searching in Stardrop by placing spaces in random places until the search finds the mod I am looking for.

This PR fixes this problem for me entirely. Now, I can search for whatever form of the name I remember and be sure to find the mod I am looking for. And then optionally click on one mod to show the whole mod group (see #150), if necessary.

Example:
- The user searches for "copper still" since he remembers that is the name of the [mod](https://www.nexusmods.com/stardewvalley/mods/15333) using the filter "Mod Group".
- The individual mods are named "[CP] Copper Still", "[JA] Copper Still", etc. indeed, but the folder name is "CopperStill".
- The search returns empty list, but with this PR included, the search correctly finds the mod group.

Tested on Linux, not tested on MacOS or Windows.