### PR TITLE
Show tooltips on Linux again

### DIFF
--- a/Stardrop/Models/Mod.cs
+++ b/Stardrop/Models/Mod.cs
@@ -25,20 +25,7 @@ namespace Stardrop.Models
         public string Name { get; set; }        
         public string Path { get; set; } // Whole mod path inside installed mods path for grouping mod components in the same mod
         public string Description { get; set; }
-        public string GetDescriptionToolTip
-        {
-            get
-            {
-                // TEMPORARY FIX: Due to bug with Avalonia on Linux platforms, tooltips currently cause crashes when they disappear
-                // To work around this, tooltips are purposely not displayed
-                if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-                {
-                    return null;
-                }
-
-                return Description;
-            }
-        }
+        public string GetDescriptionToolTip => Description;
         public string Author { get; set; }
         public Config? _config { get; set; }
         public Config? Config { get { return _config; } set { _config = value; NotifyPropertyChanged("Config"); NotifyPropertyChanged("HasConfig"); } }

--- a/Stardrop/Models/Mod.cs
+++ b/Stardrop/Models/Mod.cs
@@ -25,7 +25,6 @@ namespace Stardrop.Models
         public string Name { get; set; }        
         public string Path { get; set; } // Whole mod path inside installed mods path for grouping mod components in the same mod
         public string Description { get; set; }
-        public string GetDescriptionToolTip => Description;
         public string Author { get; set; }
         public Config? _config { get; set; }
         public Config? Config { get { return _config; } set { _config = value; NotifyPropertyChanged("Config"); NotifyPropertyChanged("HasConfig"); } }

--- a/Stardrop/ViewModels/SettingsWindowViewModel.cs
+++ b/Stardrop/ViewModels/SettingsWindowViewModel.cs
@@ -39,28 +39,20 @@ namespace Stardrop.ViewModels
 
         public SettingsWindowViewModel()
         {
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) || RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
-            {
-                ToolTip_SMAPI = Program.translation.Get("ui.settings_window.tooltips.smapi");
-                ToolTip_ModFolder = Program.translation.Get("ui.settings_window.tooltips.mod_folder_path");
-                ToolTip_ModInstall = Program.translation.Get("ui.settings_window.tooltips.mod_install_path");
-                ToolTip_Theme = Program.translation.Get("ui.settings_window.tooltips.theme");
-                ToolTip_Language = Program.translation.Get("ui.settings_window.tooltips.language");
-                ToolTip_Grouping = Program.translation.Get("ui.settings_window.tooltips.grouping");
-                ToolTip_IgnoreHiddenFolders = Program.translation.Get("ui.settings_window.tooltips.ignore_hidden_folders");
-                ToolTip_PreferredServer = Program.translation.Get("ui.settings_window.tooltips.preferred_server");
-                ToolTip_NXMAssociation = Program.translation.Get("ui.settings_window.tooltips.nxm_file_association");
-                ToolTip_AlwaysAskNXMFiles = Program.translation.Get("ui.settings_window.tooltips.always_ask_nxm_files");
-                ToolTip_EnableProfileSpecificModConfigs = Program.translation.Get("ui.settings_window.tooltips.enable_profile_specific_configs");
-                ToolTip_EnableModsOnAdd = Program.translation.Get("ui.settings_window.tooltips.enable_mods_on_add");
-                ToolTip_Save = Program.translation.Get("ui.settings_window.tooltips.save_changes");
-                ToolTip_Cancel = Program.translation.Get("ui.settings_window.tooltips.cancel_changes");
-            }
-            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-            {
-                // TEMPORARY FIX: Due to bug with Avalonia on Linux platforms, tooltips currently cause crashes when they disappear
-                // To work around this, tooltips are purposely not displayed
-            }
+            ToolTip_SMAPI = Program.translation.Get("ui.settings_window.tooltips.smapi");
+            ToolTip_ModFolder = Program.translation.Get("ui.settings_window.tooltips.mod_folder_path");
+            ToolTip_ModInstall = Program.translation.Get("ui.settings_window.tooltips.mod_install_path");
+            ToolTip_Theme = Program.translation.Get("ui.settings_window.tooltips.theme");
+            ToolTip_Language = Program.translation.Get("ui.settings_window.tooltips.language");
+            ToolTip_Grouping = Program.translation.Get("ui.settings_window.tooltips.grouping");
+            ToolTip_IgnoreHiddenFolders = Program.translation.Get("ui.settings_window.tooltips.ignore_hidden_folders");
+            ToolTip_PreferredServer = Program.translation.Get("ui.settings_window.tooltips.preferred_server");
+            ToolTip_NXMAssociation = Program.translation.Get("ui.settings_window.tooltips.nxm_file_association");
+            ToolTip_AlwaysAskNXMFiles = Program.translation.Get("ui.settings_window.tooltips.always_ask_nxm_files");
+            ToolTip_EnableProfileSpecificModConfigs = Program.translation.Get("ui.settings_window.tooltips.enable_profile_specific_configs");
+            ToolTip_EnableModsOnAdd = Program.translation.Get("ui.settings_window.tooltips.enable_mods_on_add");
+            ToolTip_Save = Program.translation.Get("ui.settings_window.tooltips.save_changes");
+            ToolTip_Cancel = Program.translation.Get("ui.settings_window.tooltips.cancel_changes");
 
             ShowMainMenu = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
             ShowNXMAssociationButton = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);

--- a/Stardrop/Views/MainWindow.axaml
+++ b/Stardrop/Views/MainWindow.axaml
@@ -449,7 +449,7 @@
 					</Style>
 					<Style Selector="DataGridRow">
 						<Setter Property="ContextMenu" Value="{StaticResource GridRowContextMenu}" />
-						<Setter Property="ToolTip.Tip" Value="{Binding GetDescriptionToolTip}" />
+						<Setter Property="ToolTip.Tip" Value="{Binding Description}" />
 					</Style>
 				</DataGrid.Styles>
 				<DataGrid.Columns>


### PR DESCRIPTION
This PR allows showing tooltips on Linux again.

The bug in Avalonia framework has been fixed and tooltips work on Linux again without any problems.
For further context, see https://github.com/Floogen/Stardrop/issues/4 and Avalonia issue concerning the bug https://github.com/AvaloniaUI/Avalonia/issues/7272.

Tested on Linux, not tested on Windows and MacOS.