### PR TITLE
Enable/Disable whole mod group(s) by selected mod(s)

### DIFF
--- a/Stardrop/Models/Mod.cs
+++ b/Stardrop/Models/Mod.cs
@@ -45,6 +45,7 @@ namespace Stardrop.Models
         private bool _isEndorsement { get; set; }
         public bool IsEndorsed { get { return _isEndorsement; } set { _isEndorsement = value; NotifyPropertyChanged("IsEndorsed"); } }
         public string ChangeStateText { get { return IsEnabled ? Program.translation.Get("internal.disable") : Program.translation.Get("internal.enable"); } }
+        public string ChangeWholeModGroupStateText  { get { return IsEnabled ? Program.translation.Get("internal.disable_whole_mod") : Program.translation.Get("internal.enable_whole_mod"); } }
         private WikiCompatibilityStatus _status { get; set; }
         public WikiCompatibilityStatus Status { get { return _status; } set { _status = value; NotifyPropertyChanged("Status"); NotifyPropertyChanged("ParsedStatus"); NotifyPropertyChanged("InstallStatus"); } }
         public string ParsedStatus

--- a/Stardrop/Models/Mod.cs
+++ b/Stardrop/Models/Mod.cs
@@ -39,7 +39,17 @@ namespace Stardrop.Models
         public string ModPageUri { get { return _modPageUri; } set { _modPageUri = value; NotifyPropertyChanged("ModPageUri"); } }
         public int? NexusModId { get { return GetNexusId(); } }
         private bool _isEnabled { get; set; }
-        public bool IsEnabled { get { return _isEnabled; } set { _isEnabled = value; NotifyPropertyChanged("IsEnabled"); NotifyPropertyChanged("ChangeStateText"); } }
+        public bool IsEnabled
+        {
+            get { return _isEnabled; }
+            set
+            {
+                _isEnabled = value;
+                NotifyPropertyChanged("IsEnabled");
+                NotifyPropertyChanged("ChangeStateText");
+                NotifyPropertyChanged("ChangeWholeModGroupStateText");
+            }
+        }
         private bool _isHidden { get; set; }
         public bool IsHidden { get { return _isHidden; } set { _isHidden = value; NotifyPropertyChanged("IsHidden"); } }
         private bool _isEndorsement { get; set; }

--- a/Stardrop/ViewModels/MainWindowViewModel.cs
+++ b/Stardrop/ViewModels/MainWindowViewModel.cs
@@ -71,8 +71,10 @@ namespace Stardrop.ViewModels
         public string NexusLimits { get { return _nexusLimits; } set { this.RaiseAndSetIfChanged(ref _nexusLimits, value); } }
         private string _smapiVersion;
         public string SmapiVersion { get { return String.IsNullOrEmpty(_smapiVersion) ? Program.translation.Get("ui.main_window.labels.unknown_SMAPI") : $"v{_smapiVersion}"; } set { this.RaiseAndSetIfChanged(ref _smapiVersion, value); } }
+
         public bool ShowSaveProfileChanges { get { return _showSaveProfileChanges; } set { this.RaiseAndSetIfChanged(ref _showSaveProfileChanges, value); } }
         private bool _showSaveProfileChanges;
+        public bool AreModGroupsEnabled { get { return Program.settings.ModGroupingMethod != ModGrouping.None; } }
 
         public MainWindowViewModel(string modsFilePath, string version)
         {

--- a/Stardrop/Views/MainWindow.axaml
+++ b/Stardrop/Views/MainWindow.axaml
@@ -444,8 +444,10 @@
 							<MenuItem Header="{i18n:Translate ui.main_window.menu_items.context.show_authors_mods}" Click="ModGridMenuRow_ShowAuthorsMods" />
 							<MenuItem Header="{i18n:Translate ui.main_window.menu_items.context.clear_filter}" Click="ModGridMenuRow_ClearFilter" />
 						</MenuItem>
-						<MenuItem Header="{Binding ChangeStateText}" Click="ModGridMenuRow_ChangeState" />
-						<MenuItem Header="{Binding ChangeWholeModGroupStateText}" Click="ModGridMenuRow_ChangeWholeModGroupState" />
+						<MenuItem Header="{Binding ChangeStateText}">
+							<MenuItem Header="{Binding ChangeStateText}" Click="ModGridMenuRow_ChangeState" />
+							<MenuItem Header="{Binding ChangeWholeModGroupStateText}" Click="ModGridMenuRow_ChangeWholeModGroupState" />
+						</MenuItem>
 						<MenuItem Header="{i18n:Translate ui.main_window.menu_items.context.delete}" Click="ModGridMenuRow_Delete" />
 						<MenuItem Header="{i18n:Translate ui.main_window.menu_items.context.cancel}" />
 					</ContextMenu>

--- a/Stardrop/Views/MainWindow.axaml
+++ b/Stardrop/Views/MainWindow.axaml
@@ -445,6 +445,7 @@
 							<MenuItem Header="{i18n:Translate ui.main_window.menu_items.context.clear_filter}" Click="ModGridMenuRow_ClearFilter" />
 						</MenuItem>
 						<MenuItem Header="{Binding ChangeStateText}" Click="ModGridMenuRow_ChangeState" />
+						<MenuItem Header="{Binding ChangeWholeModGroupStateText}" Click="ModGridMenuRow_ChangeWholeModGroupState" />
 						<MenuItem Header="{i18n:Translate ui.main_window.menu_items.context.delete}" Click="ModGridMenuRow_Delete" />
 						<MenuItem Header="{i18n:Translate ui.main_window.menu_items.context.cancel}" />
 					</ContextMenu>

--- a/Stardrop/Views/MainWindow.axaml
+++ b/Stardrop/Views/MainWindow.axaml
@@ -444,7 +444,8 @@
 							<MenuItem Header="{i18n:Translate ui.main_window.menu_items.context.show_authors_mods}" Click="ModGridMenuRow_ShowAuthorsMods" />
 							<MenuItem Header="{i18n:Translate ui.main_window.menu_items.context.clear_filter}" Click="ModGridMenuRow_ClearFilter" />
 						</MenuItem>
-						<MenuItem Header="{Binding ChangeStateText}">
+						<MenuItem Header="{Binding ChangeStateText}" Click="ModGridMenuRow_ChangeState" IsVisible="{Binding !$parent[DataGrid].DataContext.AreModGroupsEnabled}" />
+						<MenuItem Header="{Binding ChangeStateText}" IsVisible="{Binding $parent[DataGrid].DataContext.AreModGroupsEnabled}">
 							<MenuItem Header="{Binding ChangeStateText}" Click="ModGridMenuRow_ChangeState" />
 							<MenuItem Header="{Binding ChangeWholeModGroupStateText}" Click="ModGridMenuRow_ChangeWholeModGroupState" />
 						</MenuItem>

--- a/Stardrop/Views/MainWindow.axaml.cs
+++ b/Stardrop/Views/MainWindow.axaml.cs
@@ -397,40 +397,92 @@ namespace Stardrop.Views
             {
                 return;
             }
-
             var selectedMod = (sender as MenuItem).DataContext as Mod;
-            if (selectedMod is not null)
+            if (selectedMod is null)
             {
-                // Add the selected mod into the selection list if shift or ctrl is held, otherwise clear the current selection
-                if (!modGrid.SelectedItems.Contains(selectedMod))
+                return;
+            }
+            // Add the selected mod into the selection list if shift or ctrl is held, otherwise clear the current
+            //  selection.
+            if (!modGrid.SelectedItems.Contains(selectedMod))
+            {
+                if (!(_ctrlPressed || _shiftPressed))
                 {
-                    if (!(_ctrlPressed || _shiftPressed))
-                    {
-                        modGrid.SelectedItems.Clear();
-                    }
-                    modGrid.SelectedItems.Add(selectedMod);
+                    modGrid.SelectedItems.Clear();
                 }
+                modGrid.SelectedItems.Add(selectedMod);
+            }
 
-                // Enable / disable all selected mods based on the clicked mod
-                selectedMod.IsEnabled = !selectedMod.IsEnabled;
-                foreach (Mod mod in modGrid.SelectedItems)
+            EnableDisableSelectedMods(modGrid, selectedMod);
+        }
+
+        /// <summary>
+        /// Enable/Disable all mods for the mod group(s) of the selected mod(s).
+        /// </summary>
+        ///
+        /// <param name="sender">
+        /// The currently selected mod of the whole mod group whose mods to enable/disable.
+        /// </param>
+        private void ModGridMenuRow_ChangeWholeModGroupState(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
+        {
+            var modGrid = this.FindControl<DataGrid>("modGrid");
+            if (modGrid is null)
+            {
+                return;
+            }
+            var selectedMod = (sender as MenuItem)?.DataContext as Mod;
+            if (selectedMod is null)
+            {
+                return;
+            }
+
+            // Select all mods of the mod group(s) whose mod 'selectedMod' is currently selected or whose mods have 
+            //  been already selected previously.
+            var originallySelectedModPaths = new List<string>();
+            foreach (Mod mod in modGrid.SelectedItems)
+            {
+                originallySelectedModPaths.Add(mod.Path);
+            }
+            if (originallySelectedModPaths.Count is 0)
+            {
+                originallySelectedModPaths.Add(selectedMod.Path);
+            }
+            foreach (Mod mod in modGrid.Items)
+            {
+                if (originallySelectedModPaths.Contains(mod.Path))
                 {
-                    mod.IsEnabled = selectedMod.IsEnabled;
-
-                    if (selectedMod.IsEnabled)
-                    {
-                        // Enable any existing requirements
-                        EnableRequirements(mod);
-                    }
-                    else
-                    {
-                        // Disable any mods that require it requirements
-                        DisableRequirements(mod);
-                    }
+                    modGrid.SelectedItems.Add(mod);
                 }
             }
 
-            UpdateProfile(GetCurrentProfile());
+            EnableDisableSelectedMods(modGrid, selectedMod);
+        }
+
+        /// <summary>
+        /// Enable/Disable selected mods.
+        /// </summary>
+        ///
+        /// <param name="selectedMod">The currently selected which the enabling/disabling is performed on.</param>
+        private void EnableDisableSelectedMods(DataGrid? modGrid, Mod? selectedMod)
+        {
+            if (selectedMod is null || modGrid is null)
+            {
+                return;
+            }
+            // Enable / disable all selected mods based on the currently selected mod.
+            selectedMod.IsEnabled = !selectedMod.IsEnabled;
+            foreach (Mod mod in modGrid.SelectedItems)
+            {
+                mod.IsEnabled = selectedMod.IsEnabled;
+                if (selectedMod.IsEnabled)
+                {
+                    EnableRequirements(mod);
+                }
+                else
+                {
+                    DisableRequirements(mod);
+                }
+            }
         }
 
         private void ModGridMenuRow_OpenFolderPath(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
@@ -1832,6 +1884,10 @@ namespace Stardrop.Views
             this.WindowState = this.WindowState == WindowState.Normal ? WindowState.Maximized : WindowState.Normal;
         }
 
+        /// <summary>
+        /// Enable all existing requirements for <paramref name="mod" />.
+        /// </summary>
+        /// <param name="mod">The mod whose requirements to enable.</param>
         private void EnableRequirements(Mod mod)
         {
             foreach (var requirement in mod.Requirements.Where(r => r.IsRequired))
@@ -1847,6 +1903,10 @@ namespace Stardrop.Views
             }
         }
 
+        /// <summary>
+        /// Disable all mods that require the mod <paramref name="mod" />.
+        /// </summary>
+        /// <param name="mod">The mod to look for in requirements.</param>
         private void DisableRequirements(Mod mod)
         {
             foreach (var childMod in _viewModel.Mods.Where(m => m.Requirements.Any(r => r.IsRequired && r.UniqueID.Equals(mod.UniqueId, StringComparison.OrdinalIgnoreCase))))

--- a/Stardrop/Views/MainWindow.axaml.cs
+++ b/Stardrop/Views/MainWindow.axaml.cs
@@ -483,6 +483,15 @@ namespace Stardrop.Views
                     DisableRequirements(mod);
                 }
             }
+
+            if (Program.settings.ShouldAutomaticallySaveProfileChanges)
+            {
+                UpdateProfile(GetCurrentProfile());
+            }
+            else
+            {
+                _viewModel.ShowSaveProfileChanges = true;
+            }
         }
 
         private void ModGridMenuRow_OpenFolderPath(object? sender, Avalonia.Interactivity.RoutedEventArgs e)

--- a/Stardrop/Views/MainWindow.axaml.cs
+++ b/Stardrop/Views/MainWindow.axaml.cs
@@ -1410,7 +1410,14 @@ namespace Stardrop.Views
                     mod.IsEnabled = enableState;
                 }
 
-                UpdateProfile(GetCurrentProfile());
+                if (Program.settings.ShouldAutomaticallySaveProfileChanges)
+                {
+                    UpdateProfile(GetCurrentProfile());
+                }
+                else
+                {
+                    _viewModel.ShowSaveProfileChanges = true;
+                }
             }
         }
 

--- a/Stardrop/i18n/default.json
+++ b/Stardrop/i18n/default.json
@@ -216,6 +216,8 @@
   "internal.unknown": "Unknown",
   "internal.enable": "Enable",
   "internal.disable": "Disable",
+  "internal.enable_whole_mod": "Enable Whole Mod Group",
+  "internal.disable_whole_mod": "Disable Whole Mod Group",
   "internal.yes": "Yes",
   "internal.yes_all": "Yes to All",
   "internal.no": "No",


### PR DESCRIPTION
This PR adds a button to the right-click context menu to enable/disable a whole mod group based on the state of the selected mod.

If the selected mod is disabled, one can enable all mods in the group of the selected mod. If the selected mod is enabled, one can disable all the mods in the group.

This works for selecting multiple mods, even from different groups. This is especially useful when one filters on mods containing specific keyword or stored in a specific path (group name such as `automation/mod1`, `automation/mod2`, …) and wants to enable all such mods in one go.

The mod needs to be merged after #148, otherwise the changes cannot be saved.

Tested on Linux, not tested on MacOS or Windows.