### PR TITLE
Convert column search filters `ComboBox` to `ListBox` inside a `Flyout`

### DIFF
--- a/Stardrop/Utilities/NXMProtocol.cs
+++ b/Stardrop/Utilities/NXMProtocol.cs
@@ -34,7 +34,6 @@ namespace Stardrop.Utilities
         {
             try
             {
-                return false;
                 if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) is false)
                 {
                     Program.helper.Log($"Attempted to modify registery keys for NXM protocol on a non-Windows system!");

--- a/Stardrop/Utilities/NXMProtocol.cs
+++ b/Stardrop/Utilities/NXMProtocol.cs
@@ -34,6 +34,7 @@ namespace Stardrop.Utilities
         {
             try
             {
+                return false;
                 if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) is false)
                 {
                     Program.helper.Log($"Attempted to modify registery keys for NXM protocol on a non-Windows system!");

--- a/Stardrop/ViewModels/MainWindowViewModel.cs
+++ b/Stardrop/ViewModels/MainWindowViewModel.cs
@@ -596,11 +596,11 @@ namespace Stardrop.ViewModels
             if (!String.IsNullOrEmpty(_filterText) && _columnFilter.Any())
             {
                 var filterTextNoWhitespace = _filterText.Replace(" ", String.Empty);
-                if (_columnFilter.Contains(Program.translation.Get("ui.main_window.filter_listbox.mod_name")) && mod.Name.Replace(" ", String.Empty).Contains(filterTextNoWhitespace, StringComparison.OrdinalIgnoreCase))
+                if (_columnFilter.Contains(Program.translation.Get("ui.main_window.combobox.mod_name")) && mod.Name.Replace(" ", String.Empty).Contains(filterTextNoWhitespace, StringComparison.OrdinalIgnoreCase))
                 {
                     return true;
                 }
-                if (_columnFilter.Contains(Program.translation.Get("ui.main_window.filter_listbox.group")))
+                if (_columnFilter.Contains(Program.translation.Get("ui.main_window.combobox.group")))
                 {
                     ModGrouping modGroupingMethod = Program.settings.ModGroupingMethod;
                     switch (Program.settings.ModGroupingMethod)
@@ -613,11 +613,11 @@ namespace Stardrop.ViewModels
                             break;
                     }
                 }
-                if (_columnFilter.Contains(Program.translation.Get("ui.main_window.filter_listbox.author")) && mod.Author.Replace(" ", String.Empty).Contains(filterTextNoWhitespace, StringComparison.OrdinalIgnoreCase))
+                if (_columnFilter.Contains(Program.translation.Get("ui.main_window.combobox.author")) && mod.Author.Replace(" ", String.Empty).Contains(filterTextNoWhitespace, StringComparison.OrdinalIgnoreCase))
                 {
                     return true;
                 }
-                if (_columnFilter.Contains(Program.translation.Get("ui.main_window.filter_listbox.requirements")) && ((mod.HardRequirements is not null && mod.HardRequirements.Any(r => r.Name is null || r.Name.Replace(" ", String.Empty).Contains(filterTextNoWhitespace, StringComparison.OrdinalIgnoreCase))) || (mod.MissingRequirements is not null && mod.MissingRequirements.Any(r => r.Name is null || r.Name.Replace(" ", String.Empty).Contains(filterTextNoWhitespace, StringComparison.OrdinalIgnoreCase)))))
+                if (_columnFilter.Contains(Program.translation.Get("ui.main_window.combobox.requirements")) && ((mod.HardRequirements is not null && mod.HardRequirements.Any(r => r.Name is null || r.Name.Replace(" ", String.Empty).Contains(filterTextNoWhitespace, StringComparison.OrdinalIgnoreCase))) || (mod.MissingRequirements is not null && mod.MissingRequirements.Any(r => r.Name is null || r.Name.Replace(" ", String.Empty).Contains(filterTextNoWhitespace, StringComparison.OrdinalIgnoreCase)))))
                 {
                     return true;
                 }

--- a/Stardrop/ViewModels/MainWindowViewModel.cs
+++ b/Stardrop/ViewModels/MainWindowViewModel.cs
@@ -56,8 +56,8 @@ namespace Stardrop.ViewModels
         public string RequirementColumnState { get { return ShowRequirements ? Program.translation.Get("ui.main_window.menu_items.context.hide_requirements") : Program.translation.Get("ui.main_window.menu_items.context.show_requirements"); } }
         private string _filterText;
         public string FilterText { get { return _filterText; } set { _filterText = value; UpdateFilter(); } }
-        private string _columnFilter;
-        public string ColumnFilter { get { return _columnFilter; } set { _columnFilter = value; UpdateFilter(); } }
+        private List<string> _columnFilter;
+        public List<string> ColumnFilter { get { return _columnFilter; } set { _columnFilter = value; UpdateFilter(); } }
         private string _updateStatusText = Program.translation.Get("ui.main_window.button.update_status.generic");
         public string UpdateStatusText { get { return _updateStatusText; } set { this.RaiseAndSetIfChanged(ref _updateStatusText, value); } }
         private int _modsWithCachedUpdates;
@@ -588,37 +588,42 @@ namespace Stardrop.ViewModels
                 return false;
             }
 
-            if (!String.IsNullOrEmpty(_filterText) && !String.IsNullOrEmpty(_columnFilter))
+            if (String.IsNullOrEmpty(_filterText) || _columnFilter is null || !_columnFilter.Any())
+            {
+                return true;
+            }
+
+            if (!String.IsNullOrEmpty(_filterText) && _columnFilter.Any())
             {
                 var filterTextNoWhitespace = _filterText.Replace(" ", String.Empty);
-                if (_columnFilter == Program.translation.Get("ui.main_window.combobox.mod_name") && !mod.Name.Replace(" ", String.Empty).Contains(filterTextNoWhitespace, StringComparison.OrdinalIgnoreCase))
+                if (_columnFilter.Contains(Program.translation.Get("ui.main_window.filter_listbox.mod_name")) && mod.Name.Replace(" ", String.Empty).Contains(filterTextNoWhitespace, StringComparison.OrdinalIgnoreCase))
                 {
-                    return false;
+                    return true;
                 }
-                else if (_columnFilter == Program.translation.Get("ui.main_window.combobox.group"))
+                if (_columnFilter.Contains(Program.translation.Get("ui.main_window.filter_listbox.group")))
                 {
                     ModGrouping modGroupingMethod = Program.settings.ModGroupingMethod;
                     switch (Program.settings.ModGroupingMethod)
                     {
                         case ModGrouping.Folder:
-                            if (mod.Path.Replace(" ", String.Empty).Contains(filterTextNoWhitespace, StringComparison.OrdinalIgnoreCase) is false)
+                            if (mod.Path.Replace(" ", String.Empty).Contains(filterTextNoWhitespace, StringComparison.OrdinalIgnoreCase) is true)
                             {
-                                return false;
+                                return true;
                             }
                             break;
                     }
                 }
-                else if (_columnFilter == Program.translation.Get("ui.main_window.combobox.author") && !mod.Author.Replace(" ", String.Empty).Contains(filterTextNoWhitespace, StringComparison.OrdinalIgnoreCase))
+                if (_columnFilter.Contains(Program.translation.Get("ui.main_window.filter_listbox.author")) && mod.Author.Replace(" ", String.Empty).Contains(filterTextNoWhitespace, StringComparison.OrdinalIgnoreCase))
                 {
-                    return false;
+                    return true;
                 }
-                else if (_columnFilter == Program.translation.Get("ui.main_window.combobox.requirements") && !mod.HardRequirements.Any(r => r.Name is null || r.Name.Replace(" ", String.Empty).Contains(filterTextNoWhitespace, StringComparison.OrdinalIgnoreCase)) && !mod.MissingRequirements.Any(r => r.Name is null || r.Name.Replace(" ", String.Empty).Contains(filterTextNoWhitespace, StringComparison.OrdinalIgnoreCase)))
+                if (_columnFilter.Contains(Program.translation.Get("ui.main_window.filter_listbox.requirements")) && ((mod.HardRequirements is not null && mod.HardRequirements.Any(r => r.Name is null || r.Name.Replace(" ", String.Empty).Contains(filterTextNoWhitespace, StringComparison.OrdinalIgnoreCase))) || (mod.MissingRequirements is not null && mod.MissingRequirements.Any(r => r.Name is null || r.Name.Replace(" ", String.Empty).Contains(filterTextNoWhitespace, StringComparison.OrdinalIgnoreCase)))))
                 {
-                    return false;
+                    return true;
                 }
             }
 
-            return true;
+            return false;
         }
     }
 }

--- a/Stardrop/Views/MainWindow.axaml
+++ b/Stardrop/Views/MainWindow.axaml
@@ -570,9 +570,12 @@
 			<Button Name="searchFilterColumn" Content="{i18n:Translate ui.main_window.buttons.column_search_filters}" VerticalAlignment="Center" Margin="5 0 0 0" Foreground="{DynamicResource ThemeForegroundBrush}" Background="Transparent" BorderBrush="{DynamicResource HighlightBrush}">
 				<Button.Flyout>
 	        <Flyout>
-						<ListBox x:Name="searchFilterColumnBox"
-							SelectionMode="Multiple,Toggle" SelectedIndex="0"
-							Margin="5 2 0 0" Background="{DynamicResource ThemeBackgroundBrush}" Foreground="{DynamicResource ThemeForegroundBrush}" FontWeight="Bold" BorderBrush="{DynamicResource HighlightBrush}" Width="150" />
+				<ListBox x:Name="searchFilterColumnBox" SelectionMode="Multiple,Toggle" SelectedIndex="0" Margin="5 2 0 0" Background="{DynamicResource ThemeBackgroundBrush}" Foreground="{DynamicResource ThemeForegroundBrush}" FontWeight="Bold" BorderBrush="{DynamicResource HighlightBrush}" Width="150">
+					<ListBoxItem Content="{i18n:Translate ui.main_window.combobox.author}" />
+					<ListBoxItem Content="{i18n:Translate ui.main_window.combobox.mod_name}" />
+					<ListBoxItem Content="{i18n:Translate ui.main_window.combobox.group}" />
+					<ListBoxItem Content="{i18n:Translate ui.main_window.combobox.requirements}" />
+				</ListBox>
 	        </Flyout>
 		    </Button.Flyout>
 			</Button>

--- a/Stardrop/Views/MainWindow.axaml
+++ b/Stardrop/Views/MainWindow.axaml
@@ -567,12 +567,15 @@
 		</Border>
 		<DockPanel Name="filterBar" Grid.Row="4" Grid.Column="0" Margin="7 0 0 5">
 			<TextBox Name="searchBox" Watermark="{i18n:Translate ui.main_window.labels.filter}" Height="10" Width="250" BorderBrush="{DynamicResource HighlightBrush}" HorizontalAlignment="Left"/>
-			<ComboBox x:Name="searchFilterColumnBox" Margin="5 2 0 0" Background="{DynamicResource ThemeBackgroundBrush}" Foreground="{DynamicResource ThemeForegroundBrush}" FontWeight="Bold" BorderBrush="{DynamicResource HighlightBrush}" SelectedIndex="0" Width="150">
-				<ComboBoxItem Content="{i18n:Translate ui.main_window.combobox.author}" />
-				<ComboBoxItem Content="{i18n:Translate ui.main_window.combobox.mod_name}" />
-				<ComboBoxItem Content="{i18n:Translate ui.main_window.combobox.group}" />
-				<ComboBoxItem Content="{i18n:Translate ui.main_window.combobox.requirements}" />
-			</ComboBox>
+			<Button Name="searchFilterColumn" Content="{i18n:Translate ui.main_window.buttons.column_search_filters}" VerticalAlignment="Center" Margin="5 0 0 0" Foreground="{DynamicResource ThemeForegroundBrush}" Background="Transparent" BorderBrush="{DynamicResource HighlightBrush}">
+				<Button.Flyout>
+	        <Flyout>
+						<ListBox x:Name="searchFilterColumnBox"
+							SelectionMode="Multiple,Toggle" SelectedIndex="0"
+							Margin="5 2 0 0" Background="{DynamicResource ThemeBackgroundBrush}" Foreground="{DynamicResource ThemeForegroundBrush}" FontWeight="Bold" BorderBrush="{DynamicResource HighlightBrush}" Width="150" />
+	        </Flyout>
+		    </Button.Flyout>
+			</Button>
 			<StackPanel Orientation="Horizontal" Margin="10 0 10 0">
 				<Separator Width="1" Height="15" Background="{DynamicResource HighlightBrush}" />
 			</StackPanel>

--- a/Stardrop/Views/MainWindow.axaml
+++ b/Stardrop/Views/MainWindow.axaml
@@ -583,7 +583,7 @@
 		</Border>
 		<DockPanel Name="filterBar" Grid.Row="4" Grid.Column="0" Margin="7 0 0 5">
 			<TextBox Name="searchBox" Watermark="{i18n:Translate ui.main_window.labels.filter}" Height="10" Width="250" BorderBrush="{DynamicResource HighlightBrush}" HorizontalAlignment="Left"/>
-			<Button Name="searchFilterColumn" Content="{i18n:Translate ui.main_window.buttons.column_search_filters}" VerticalAlignment="Center" Margin="5 0 0 0" Foreground="{DynamicResource ThemeForegroundBrush}" Background="Transparent" BorderBrush="{DynamicResource HighlightBrush}">
+			<Button Name="searchFilterColumnButton" Content="{i18n:Translate ui.main_window.buttons.no_search_filters}" VerticalAlignment="Center" Margin="5 0 0 0" Foreground="{DynamicResource ThemeForegroundBrush}" Background="Transparent" BorderBrush="{DynamicResource HighlightBrush}">
 				<Button.Flyout>
 					<Flyout FlyoutPresenterClasses="FilterBoxFlyout">
 						<ListBox x:Name="searchFilterColumnBox" Name="FilterBox" SelectionMode="Multiple,Toggle" SelectedIndex="0" Margin="5 2 0 0" Background="{DynamicResource ThemeBackgroundBrush}" Foreground="{DynamicResource ThemeForegroundBrush}" FontWeight="Bold" BorderBrush="{DynamicResource HighlightBrush}" Width="150">

--- a/Stardrop/Views/MainWindow.axaml
+++ b/Stardrop/Views/MainWindow.axaml
@@ -30,6 +30,10 @@
 	</Window.Resources>
 
 	<Window.Styles>
+		<Style Selector="FlyoutPresenter.FilterBoxFlyout">
+			<Setter Property="Background" Value="Transparent"/>
+			<Setter Property="BorderThickness" Value="0"/>
+		</Style>
 		<Style Selector="MenuItem.Bar Separator">
 			<Setter Property="Border.Background" Value="{DynamicResource HighlightForegroundBrush}"/>
 		</Style>
@@ -262,6 +266,10 @@
 		<Style Selector="DataGridRow:selected /template/ Rectangle#BackgroundRectangle">
 			<Setter Property="Fill" Value="{DynamicResource HighlightForegroundBrush}"/>
 		</Style>
+		<Style Selector="ListBox#FilterBox">
+			<Setter Property="BorderBrush" Value="{DynamicResource ThemeBorderMidBrush}" />
+			<Setter Property="BorderThickness" Value="1" />
+		</Style>
 		<Style Selector="ListBoxItem">
 			<Setter Property="HorizontalContentAlignment" Value="Center" />
 		</Style>
@@ -271,6 +279,14 @@
 		</Style>
 		<Style Selector="ListBoxItem:selected /template/ ContentPresenter">
 			<Setter Property="Background" Value="Transparent"/>
+		</Style>
+		<Style Selector="ListBoxItem.FilterItemBox:not(:selected) /template/ ContentPresenter">
+			<Setter Property="TextBlock.Foreground" Value="{DynamicResource ThemeForegroundBrush}"/>
+			<Setter Property="TextBlock.Opacity" Value="0.25"/>
+		</Style>
+		<Style Selector="ListBoxItem.FilterItemBox:selected /template/ ContentPresenter">
+			<Setter Property="TextBlock.Foreground" Value="{DynamicResource ThemeForegroundBrush}"/>
+			<Setter Property="TextBlock.Opacity" Value="1"/>
 		</Style>
 		<Style Selector="TextBox:focus">
 			<Setter Property="Foreground" Value="White"/>
@@ -569,14 +585,14 @@
 			<TextBox Name="searchBox" Watermark="{i18n:Translate ui.main_window.labels.filter}" Height="10" Width="250" BorderBrush="{DynamicResource HighlightBrush}" HorizontalAlignment="Left"/>
 			<Button Name="searchFilterColumn" Content="{i18n:Translate ui.main_window.buttons.column_search_filters}" VerticalAlignment="Center" Margin="5 0 0 0" Foreground="{DynamicResource ThemeForegroundBrush}" Background="Transparent" BorderBrush="{DynamicResource HighlightBrush}">
 				<Button.Flyout>
-	        <Flyout>
-				<ListBox x:Name="searchFilterColumnBox" SelectionMode="Multiple,Toggle" SelectedIndex="0" Margin="5 2 0 0" Background="{DynamicResource ThemeBackgroundBrush}" Foreground="{DynamicResource ThemeForegroundBrush}" FontWeight="Bold" BorderBrush="{DynamicResource HighlightBrush}" Width="150">
-					<ListBoxItem Content="{i18n:Translate ui.main_window.combobox.author}" />
-					<ListBoxItem Content="{i18n:Translate ui.main_window.combobox.mod_name}" />
-					<ListBoxItem Content="{i18n:Translate ui.main_window.combobox.group}" />
-					<ListBoxItem Content="{i18n:Translate ui.main_window.combobox.requirements}" />
-				</ListBox>
-	        </Flyout>
+					<Flyout FlyoutPresenterClasses="FilterBoxFlyout">
+						<ListBox x:Name="searchFilterColumnBox" Name="FilterBox" SelectionMode="Multiple,Toggle" SelectedIndex="0" Margin="5 2 0 0" Background="{DynamicResource ThemeBackgroundBrush}" Foreground="{DynamicResource ThemeForegroundBrush}" FontWeight="Bold" BorderBrush="{DynamicResource HighlightBrush}" Width="150">
+							<ListBoxItem Content="{i18n:Translate ui.main_window.combobox.author}" Classes="FilterItemBox" />
+							<ListBoxItem Content="{i18n:Translate ui.main_window.combobox.mod_name}" Classes="FilterItemBox" />
+							<ListBoxItem Content="{i18n:Translate ui.main_window.combobox.group}" Classes="FilterItemBox" />
+							<ListBoxItem Content="{i18n:Translate ui.main_window.combobox.requirements}" Classes="FilterItemBox" />
+						</ListBox>
+					</Flyout>
 		    </Button.Flyout>
 			</Button>
 			<StackPanel Orientation="Horizontal" Margin="10 0 10 0">

--- a/Stardrop/Views/MainWindow.axaml.cs
+++ b/Stardrop/Views/MainWindow.axaml.cs
@@ -137,8 +137,8 @@ namespace Stardrop.Views
 
             // Handle filtering by searchFilterColumnBox
             var searchFilterColumnBox = this.FindControl<ListBox>("searchFilterColumnBox");
-            searchFilterColumnBox.SelectedItem = searchFilterColumnBox.Items.Cast<ListBoxItem>().First(c => c.Content.ToString() == Program.translation.Get("ui.main_window.combobox.mod_name"));
             searchFilterColumnBox.SelectionChanged += FilterListBox_SelectionChanged;
+            searchFilterColumnBox.SelectedItem = searchFilterColumnBox.Items.Cast<ListBoxItem>().First(c => c.Content.ToString() == Program.translation.Get("ui.main_window.combobox.mod_name"));
 
             var disabledModFilterColumnBox = this.FindControl<ComboBox>("disabledModFilterColumnBox");
             disabledModFilterColumnBox.SelectedIndex = 0;

--- a/Stardrop/Views/MainWindow.axaml.cs
+++ b/Stardrop/Views/MainWindow.axaml.cs
@@ -580,6 +580,9 @@ namespace Stardrop.Views
         {
             var searchFilterColumnBox = (e.Source as ListBox);
             _viewModel.ColumnFilter = searchFilterColumnBox.SelectedItems.Cast<ListBoxItem>().Select(i => i.Content.ToString()).ToList();
+
+            int selectedItemCount = searchFilterColumnBox.SelectedItems.Count;
+            this.FindControl<Button>("searchFilterColumnButton").Content = selectedItemCount > 0 ? String.Format(Program.translation.Get("ui.main_window.buttons.active_search_filters"), selectedItemCount) : Program.translation.Get("ui.main_window.buttons.no_search_filters");
         }
 
         private void DisabledModComboBox_SelectionChanged(object? sender, SelectionChangedEventArgs e)

--- a/Stardrop/Views/MainWindow.axaml.cs
+++ b/Stardrop/Views/MainWindow.axaml.cs
@@ -136,9 +136,17 @@ namespace Stardrop.Views
             this.FindControl<TextBox>("searchBox").AddHandler(KeyUpEvent, SearchBox_KeyUp);
 
             // Handle filtering by searchFilterColumnBox
-            var searchFilterColumnBox = this.FindControl<ComboBox>("searchFilterColumnBox");
-            searchFilterColumnBox.SelectedItem = searchFilterColumnBox.Items.Cast<ComboBoxItem>().First(c => c.Content.ToString() == Program.translation.Get("ui.main_window.combobox.mod_name"));
-            searchFilterColumnBox.SelectionChanged += FilterComboBox_SelectionChanged;
+            var searchFilterColumnBox = this.FindControl<ListBox>("searchFilterColumnBox");
+            searchFilterColumnBox.Items = new string[] {
+                Program.translation.Get("ui.main_window.filter_listbox.author"),
+                Program.translation.Get("ui.main_window.filter_listbox.mod_name"),
+                Program.translation.Get("ui.main_window.filter_listbox.group"),
+                Program.translation.Get("ui.main_window.filter_listbox.requirements")
+            };
+            var searchFilterSelectedItems = new List<string>();
+            searchFilterSelectedItems.Add(Program.translation.Get("ui.main_window.filter_listbox.mod_name"));
+            searchFilterColumnBox.SelectedItems = searchFilterSelectedItems;
+            searchFilterColumnBox.SelectionChanged += FilterListBox_SelectionChanged;
 
             var disabledModFilterColumnBox = this.FindControl<ComboBox>("disabledModFilterColumnBox");
             disabledModFilterColumnBox.SelectedIndex = 0;
@@ -464,7 +472,7 @@ namespace Stardrop.Views
 
             var searchFilterColumnBox = this.FindControl<ComboBox>("searchFilterColumnBox");
             searchFilterColumnBox.SelectedItem = searchFilterColumnBox.Items.Cast<ComboBoxItem>().First(c => c.Content.ToString() == Program.translation.Get("ui.main_window.combobox.group"));
-            
+
             this.FindControl<TextBox>("searchBox").Text = selectedMod.Path;
             _viewModel.FilterText = selectedMod.Path;
         }
@@ -482,7 +490,7 @@ namespace Stardrop.Views
 
             this.FindControl<TextBox>("searchBox").Text = selectedMod.Author;
             _viewModel.FilterText = selectedMod.Author;
-        }        
+        }
 
         private void ModGridMenuRow_ClearFilter(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
         {
@@ -569,17 +577,17 @@ namespace Stardrop.Views
             _viewModel.FilterText = filterText;
 
             // Ensure the ColumnFilter is set
-            if (String.IsNullOrEmpty(_viewModel.ColumnFilter))
+            if (_viewModel.ColumnFilter is null || _viewModel.ColumnFilter.Any() is false)
             {
-                var searchFilterColumnBox = this.FindControl<ComboBox>("searchFilterColumnBox");
-                _viewModel.ColumnFilter = (searchFilterColumnBox.SelectedItem as ComboBoxItem).Content.ToString();
+                var searchFilterColumnBox = this.FindControl<ListBox>("searchFilterColumnBox");
+                _viewModel.ColumnFilter = searchFilterColumnBox.SelectedItems.Cast<string>().ToList();
             }
         }
 
-        private void FilterComboBox_SelectionChanged(object? sender, SelectionChangedEventArgs e)
+        private void FilterListBox_SelectionChanged(object? sender, SelectionChangedEventArgs e)
         {
-            var searchFilterColumnBox = (e.Source as ComboBox);
-            _viewModel.ColumnFilter = (searchFilterColumnBox.SelectedItem as ComboBoxItem).Content.ToString();
+            var searchFilterColumnBox = (e.Source as ListBox);
+            _viewModel.ColumnFilter = searchFilterColumnBox.SelectedItems.Cast<string>().ToList();
         }
 
         private void DisabledModComboBox_SelectionChanged(object? sender, SelectionChangedEventArgs e)

--- a/Stardrop/Views/MainWindow.axaml.cs
+++ b/Stardrop/Views/MainWindow.axaml.cs
@@ -137,15 +137,7 @@ namespace Stardrop.Views
 
             // Handle filtering by searchFilterColumnBox
             var searchFilterColumnBox = this.FindControl<ListBox>("searchFilterColumnBox");
-            searchFilterColumnBox.Items = new string[] {
-                Program.translation.Get("ui.main_window.filter_listbox.author"),
-                Program.translation.Get("ui.main_window.filter_listbox.mod_name"),
-                Program.translation.Get("ui.main_window.filter_listbox.group"),
-                Program.translation.Get("ui.main_window.filter_listbox.requirements")
-            };
-            var searchFilterSelectedItems = new List<string>();
-            searchFilterSelectedItems.Add(Program.translation.Get("ui.main_window.filter_listbox.mod_name"));
-            searchFilterColumnBox.SelectedItems = searchFilterSelectedItems;
+            searchFilterColumnBox.SelectedItem = searchFilterColumnBox.Items.Cast<ListBoxItem>().First(c => c.Content.ToString() == Program.translation.Get("ui.main_window.combobox.mod_name"));
             searchFilterColumnBox.SelectionChanged += FilterListBox_SelectionChanged;
 
             var disabledModFilterColumnBox = this.FindControl<ComboBox>("disabledModFilterColumnBox");
@@ -580,14 +572,14 @@ namespace Stardrop.Views
             if (_viewModel.ColumnFilter is null || _viewModel.ColumnFilter.Any() is false)
             {
                 var searchFilterColumnBox = this.FindControl<ListBox>("searchFilterColumnBox");
-                _viewModel.ColumnFilter = searchFilterColumnBox.SelectedItems.Cast<string>().ToList();
+                _viewModel.ColumnFilter = searchFilterColumnBox.SelectedItems.Cast<ListBoxItem>().Select(i => i.Content.ToString()).ToList();
             }
         }
 
         private void FilterListBox_SelectionChanged(object? sender, SelectionChangedEventArgs e)
         {
             var searchFilterColumnBox = (e.Source as ListBox);
-            _viewModel.ColumnFilter = searchFilterColumnBox.SelectedItems.Cast<string>().ToList();
+            _viewModel.ColumnFilter = searchFilterColumnBox.SelectedItems.Cast<ListBoxItem>().Select(i => i.Content.ToString()).ToList();
         }
 
         private void DisabledModComboBox_SelectionChanged(object? sender, SelectionChangedEventArgs e)

--- a/Stardrop/i18n/default.json
+++ b/Stardrop/i18n/default.json
@@ -68,6 +68,7 @@
   "ui.main_window.buttons.save_configs": "Save Configs",
   "ui.main_window.buttons.hide_disabled_mods": "Hide Disabled Mods",
   "ui.main_window.buttons.show_updatable_mods": "Show Updatable Mods",
+  "ui.main_window.buttons.column_search_filters": "Column Search Filters",
 
   // Main Window - Buttons - Update Status
   "ui.main_window.button.update_status.generic": "Click To Check For Mod Updates",
@@ -78,10 +79,12 @@
   // Main Window - ComboBox
   "ui.main_window.combobox.show_all_mods": "Show All Mods",
   "ui.main_window.combobox.hide_enabled_mods": "Hide Enabled Mods",
-  "ui.main_window.combobox.mod_name": "Mod Name",
-  "ui.main_window.combobox.author": "Author",
-  "ui.main_window.combobox.requirements": "Requirements",
-  "ui.main_window.combobox.group": "Mod Group",
+
+  // Main Window - search filter ListBox
+  "ui.main_window.filter_listbox.mod_name": "Mod Name",
+  "ui.main_window.filter_listbox.author": "Author",
+  "ui.main_window.filter_listbox.requirements": "Requirements",
+  "ui.main_window.filter_listbox.group": "Mod Group",
 
   // Settings Window - Labels
   "ui.settings_window.labels.smapi_path": "SMAPI Path",

--- a/Stardrop/i18n/default.json
+++ b/Stardrop/i18n/default.json
@@ -80,11 +80,11 @@
   "ui.main_window.combobox.show_all_mods": "Show All Mods",
   "ui.main_window.combobox.hide_enabled_mods": "Hide Enabled Mods",
 
-  // Main Window - search filter ListBox
-  "ui.main_window.filter_listbox.mod_name": "Mod Name",
-  "ui.main_window.filter_listbox.author": "Author",
-  "ui.main_window.filter_listbox.requirements": "Requirements",
-  "ui.main_window.filter_listbox.group": "Mod Group",
+  // Main Window - ComboBox (ListBox)
+  "ui.main_window.combobox.mod_name": "Mod Name",
+  "ui.main_window.combobox.author": "Author",
+  "ui.main_window.combobox.requirements": "Requirements",
+  "ui.main_window.combobox.group": "Mod Group",
 
   // Settings Window - Labels
   "ui.settings_window.labels.smapi_path": "SMAPI Path",

--- a/Stardrop/i18n/default.json
+++ b/Stardrop/i18n/default.json
@@ -68,7 +68,8 @@
   "ui.main_window.buttons.save_configs": "Save Configs",
   "ui.main_window.buttons.hide_disabled_mods": "Hide Disabled Mods",
   "ui.main_window.buttons.show_updatable_mods": "Show Updatable Mods",
-  "ui.main_window.buttons.column_search_filters": "Column Search Filters",
+  "ui.main_window.buttons.active_search_filters": "{0} Filter(s) Active",
+  "ui.main_window.buttons.no_search_filters": "No Filters Active",
 
   // Main Window - Buttons - Update Status
   "ui.main_window.button.update_status.generic": "Click To Check For Mod Updates",


### PR DESCRIPTION
This PR implements the multi-select feature for column search filters. It enables opening a flyout with column search filters, where one can select multiple filters.

This PR serves as an initial implementation of the functionality for filtering on multiple columns, as discussed in https://github.com/Floogen/Stardrop/pull/143#pullrequestreview-1799531288. Option to set default filters in the settings menu is currently missing and is WIP.

Styling for the UI elements is missing. If you like the implementation, I would appreciate it if you could apply suitable styles to the added `Flyout` and `ListBox` elements.

What do you think about this approach, functionality-wise? I think this is simpler than adding an arbitrary list with checkboxes for each column filter, which would have to be each manually handled. If you find this interesting, feel free to modify the code as you see fit.

The PR was tested on Linux, not tested on Windows and MacOS.