### PR TITLE
Set correct mod install path

### DIFF
--- a/Stardrop/Views/MainWindow.axaml.cs
+++ b/Stardrop/Views/MainWindow.axaml.cs
@@ -2033,7 +2033,7 @@ namespace Stardrop.Views
                                 }
 
                                 SetLockState(false);
-                                addedMods.Add(new Mod(manifest, null, manifest.UniqueID, manifest.Version, manifest.Name, manifest.Description, manifest.Author));
+                                addedMods.Add(new Mod(manifest, new FileInfo(Path.Join(installPath, manifestFolderPath)), manifest.UniqueID, manifest.Version, manifest.Name, manifest.Description, manifest.Author));
                             }
                             else
                             {


### PR DESCRIPTION
This PR fixes setting manifest path during installation/update of mods so that `Mod.Path` for the mod can be correctly computed. Without setting the path properly, no mod can be added/updated.

I am not sure how it happened, but apparently I forgot to include this commit in the previous PRs due to the refactorization of #146, and since the PRs were separated by features, adding mods with mod grouping mode was never tested in the upstream version, it seems.

Tested on Linux, not tested on Windows or MacOS.