### PR TITLE
Swap from creating Symlinks with ProcessInfo for api

### DIFF
--- a/Stardrop/Models/ModToLinkPath.cs
+++ b/Stardrop/Models/ModToLinkPath.cs
@@ -1,0 +1,6 @@
+﻿namespace Stardrop.Models;
+public class ModToLinkPath
+{
+    public string LinkPath { get; set; } = string.Empty;
+    public string ModPath { get; set; } = string.Empty;
+}

--- a/Stardrop/Views/MainWindow.axaml.cs
+++ b/Stardrop/Views/MainWindow.axaml.cs
@@ -2224,49 +2224,6 @@ namespace Stardrop.Views
             return addedMods;
         }
 
-        private void CreateDirectoryJunctions(List<string> arguments)
-        {
-            // Prepare the process
-            var processInfo = new ProcessStartInfo
-            {
-                FileName = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "cmd" : "/bin/bash",
-                Arguments = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? $"/C {string.Join(" & ", arguments)}" : $"-c \"{string.Join(" ; ", arguments)}\"",
-                RedirectStandardOutput = true,
-                RedirectStandardError = true,
-                CreateNoWindow = true,
-                UseShellExecute = false
-            };
-
-            try
-            {
-                Program.helper.Log($"Starting process to link folders via terminal using {processInfo.FileName} and an argument length of {processInfo.Arguments.Length}");
-
-                using (var process = Process.Start(processInfo))
-                {
-                    // Synchronously read the standard output / error of the spawned process.
-                    var standardOutput = process.StandardOutput.ReadToEnd();
-                    var errorOutput = process.StandardError.ReadToEnd();
-
-                    Program.helper.Log($"Standard Output: {(String.IsNullOrWhiteSpace(standardOutput) ? "Empty" : String.Concat(Environment.NewLine, standardOutput))}");
-                    Program.helper.Log($"Error Output: {(String.IsNullOrWhiteSpace(errorOutput) ? "Empty" : String.Concat(Environment.NewLine, errorOutput))}");
-
-                    if (!String.IsNullOrWhiteSpace(errorOutput))
-                    {
-                        Program.helper.Log($"Printing full argument chain due to error output being detected: {Environment.NewLine}{processInfo.Arguments}");
-                    }
-
-                    process.WaitForExit();
-                }
-
-                Program.helper.Log($"Link process completed");
-            }
-            catch (Exception ex)
-            {
-                Program.helper.Log($"Process failed for creating mod folder links using {processInfo.FileName} with arguments: {processInfo.Arguments}");
-                Program.helper.Log($"Exception for failed mod folder link creation: {ex}");
-            }
-        }
-
         private void UpdateEnabledModsFolder(Profile profile, string enabledModsPath)
         {
             // Clear any previous linked mods
@@ -2279,7 +2236,7 @@ namespace Stardrop.Views
             Program.helper.Log($"Creating links for the following enabled mods from profile {profile.Name}:{spacing}{String.Join(spacing, profile.EnabledModIds)}");
 
             // Link the enabled mods via a chained command
-            List<string> arguments = new List<string>();
+            var linkPathList = new List<ModToLinkPath>();
             foreach (string modId in _viewModel.Mods.Where(m => m.IsEnabled).Select(m => m.UniqueId))
             {
                 var mod = _viewModel.Mods.FirstOrDefault(m => m.UniqueId == modId);
@@ -2288,61 +2245,21 @@ namespace Stardrop.Views
                     continue;
                 }
 
-                if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                var linkPath = Path.Combine(enabledModsPath, mod.ModFileInfo.Directory.Name);
+                var modDirectoryName = mod.ModFileInfo.DirectoryName;
+                linkPathList.Add(new ModToLinkPath
                 {
-                    var longPathPrefix = @"\\?\";
-
-                    var linkPath = Path.Combine(enabledModsPath, mod.ModFileInfo.Directory.Name);
-                    if (linkPath.Length >= 260)
-                    {
-                        linkPath = longPathPrefix + linkPath;
-                    }
-
-                    var modDirectoryName = mod.ModFileInfo.DirectoryName;
-                    if (Path.Combine(enabledModsPath, mod.ModFileInfo.Directory.Name).Length >= 260)
-                    {
-                        modDirectoryName = longPathPrefix + modDirectoryName;
-                    }
-
-                    arguments.Add($"mklink /J \"{linkPath}\" \"{modDirectoryName}\"");
-                }
-                else
-                {
-                    var edq = "\\\""; // Escaped double quotes, to prevent issues with paths that contain single quotes
-                    arguments.Add($"ln -sf {edq}{mod.ModFileInfo.DirectoryName}{edq} {edq}{Path.Combine(enabledModsPath, mod.ModFileInfo.Directory.Name)}{edq}");
-                }
+                    ModPath = modDirectoryName,
+                    LinkPath = linkPath
+                });
             }
 
             // Attempt to create the directory junction
             try
             {
-                int maxArgumentLength = 8000;
-                if (arguments.Sum(a => a.Length) + (arguments.Count * 3) >= maxArgumentLength)
-                {
-                    int argumentIndex = 0;
-                    var segmentedArguments = new List<string>();
-                    while (arguments.ElementAtOrDefault(argumentIndex) is not null)
-                    {
-                        if (arguments[argumentIndex].Length + segmentedArguments.Sum(a => a.Length) + (segmentedArguments.Count * 3) >= maxArgumentLength)
-                        {
-                            // Create the process and clear segmentedArguments
-                            CreateDirectoryJunctions(segmentedArguments);
-                            segmentedArguments.Clear();
-                        }
-                        segmentedArguments.Add(arguments[argumentIndex]);
-                        argumentIndex++;
+                CreateSymlinkDirectories(linkPathList);
 
-                        // Check if the next index is null, if so then push the changes
-                        if (arguments.ElementAtOrDefault(argumentIndex) is null && segmentedArguments.Count > 0)
-                        {
-                            CreateDirectoryJunctions(segmentedArguments);
-                        }
-                    }
-                }
-                else
-                {
-                    CreateDirectoryJunctions(arguments);
-                }
+
             }
             catch (Exception ex)
             {
@@ -2350,6 +2267,14 @@ namespace Stardrop.Views
             }
 
             Program.helper.Log($"Finished creating all linked mod folders");
+        }
+
+        private void CreateSymlinkDirectories(List<ModToLinkPath> modToLinkPaths)
+        {
+            modToLinkPaths.ForEach(modToLinkPath =>
+            {
+                Directory.CreateSymbolicLink(modToLinkPath.LinkPath, modToLinkPath.ModPath);
+            });
         }
 
         private void OpenNativeExplorer(string folderPath)


### PR DESCRIPTION
This changes creating symbolic links from the outside process to creating them via the [api](https://learn.microsoft.com/en-us/dotnet/api/system.io.directory.createsymboliclink?view=net-7.0). This should reduce the time it takes to create the symbolic links. 

Testing loading in 80 mods
1. Process Info took around 1.7 secs
2. Using api takes < 100ms

Before:  
![image](https://github.com/Floogen/Stardrop/assets/72272567/4b9a69ca-3ba5-420d-a652-b0c15462f526)

After:  
![image](https://github.com/Floogen/Stardrop/assets/72272567/eb9c90e5-ed7c-4cb9-87a9-eee5931e3e48)
