### PR TITLE
Adjust Settings window so that content expands as it resizes

### DIFF
--- a/Stardrop/Views/MainWindow.axaml.cs
+++ b/Stardrop/Views/MainWindow.axaml.cs
@@ -1230,7 +1230,7 @@ namespace Stardrop.Views
         {
             Program.helper.Log($"Opening settings window");
 
-            var editorWindow = new SettingsWindow(this);
+            var editorWindow = new SettingsWindow(this.Height);
             editorWindow.WindowStartupLocation = WindowStartupLocation.CenterOwner;
             if (await editorWindow.ShowDialog<bool>(this))
             {

--- a/Stardrop/Views/MainWindow.axaml.cs
+++ b/Stardrop/Views/MainWindow.axaml.cs
@@ -1230,7 +1230,7 @@ namespace Stardrop.Views
         {
             Program.helper.Log($"Opening settings window");
 
-            var editorWindow = new SettingsWindow();
+            var editorWindow = new SettingsWindow(this);
             editorWindow.WindowStartupLocation = WindowStartupLocation.CenterOwner;
             if (await editorWindow.ShowDialog<bool>(this))
             {

--- a/Stardrop/Views/SettingsWindow.axaml
+++ b/Stardrop/Views/SettingsWindow.axaml
@@ -11,7 +11,6 @@
         MinWidth="430"
         MinHeight="430"
         Width="430"
-        Height="500"
         Background="{DynamicResource ThemeBackgroundBrush}"
         HasSystemDecorations="true"
         ExtendClientAreaToDecorationsHint="true"

--- a/Stardrop/Views/SettingsWindow.axaml
+++ b/Stardrop/Views/SettingsWindow.axaml
@@ -157,12 +157,8 @@
 	<Grid>
 		<Grid.RowDefinitions>
 			<RowDefinition Height="Auto" />
+			<RowDefinition Height="*" />
 			<RowDefinition Height="Auto" />
-			<RowDefinition Height="Auto" />
-			<RowDefinition Height="Auto" />
-			<RowDefinition Height="Auto" />
-			<RowDefinition Height="25" />
-			<RowDefinition Height="50" />
 			<RowDefinition Height="Auto" />
 		</Grid.RowDefinitions>
 
@@ -170,19 +166,20 @@
 			<ColumnDefinition Width="*" />
 			<ColumnDefinition Width="Auto" />
 		</Grid.ColumnDefinitions>
+        
 		<Border Grid.Row="0" BorderBrush="{DynamicResource HighlightBrush}" BorderThickness="0 0 0 2" Grid.ColumnSpan="2">
 			<Menu Name="menuBar" KeyboardNavigation.TabNavigation="None">
 				<Image Source="/Assets/icon.ico" Stretch="None"/>
 				<TextBlock Text="{i18n:Translate ui.window.settings.name}" Margin="-10 0 0 0" VerticalAlignment="Center" HorizontalAlignment="Left" Foreground="{DynamicResource ThemeForegroundBrush}" />
 			</Menu>
 		</Border>
-		<Menu Name="windowMenu" IsVisible="{Binding ShowMainMenu}" HorizontalAlignment="Right" KeyboardNavigation.TabNavigation="None" Grid.Column="1">
+		<Menu Name="windowMenu" Grid.Row="0" IsVisible="{Binding ShowMainMenu}" HorizontalAlignment="Right" KeyboardNavigation.TabNavigation="None" Grid.Column="1">
 			<Button Name="exitButton" i:Attached.Icon="mdi-close" Margin="0 0 -10 0" Foreground="{DynamicResource ThemeForegroundBrush}" Background="Transparent"/>
 		</Menu>
 
-		<ScrollViewer AllowAutoHide="True" Height="350" Grid.Row="1" Grid.ColumnSpan="2">
+		<ScrollViewer AllowAutoHide="True" Grid.Row="1" Grid.ColumnSpan="2">
 			<StackPanel>
-				<StackPanel Grid.Row="1" Grid.ColumnSpan="2" Margin="10 10 0 0">
+				<StackPanel Margin="10 10 0 0">
 					<TextBlock Text="{i18n:Translate ui.settings_window.labels.smapi_path}" VerticalAlignment="Center" HorizontalAlignment="Left" Foreground="{DynamicResource ThemeForegroundBrush}" />
 					<TextBox Name="smapiFolderPathBox" Text="{Binding SMAPIPath}" ToolTip.Tip="{Binding ToolTip_SMAPI}" Margin="10 10 0 0" Height="10" Width="350" BorderBrush="{DynamicResource HighlightBrush}" HorizontalAlignment="Left"/>
 					<Button Name="smapiFolderButton" Margin="360 -32 0 0" i:Attached.Icon="mdi-folder" Foreground="{DynamicResource ThemeForegroundBrush}" Background="Transparent" HorizontalAlignment="Left" />
@@ -196,7 +193,7 @@
 					<Button Name="modInstallButton" Margin="360 -32 0 0" i:Attached.Icon="mdi-folder" Foreground="{DynamicResource ThemeForegroundBrush}" Background="Transparent" HorizontalAlignment="Left" />
 				</StackPanel>
 
-				<StackPanel Grid.Row="2" Margin="10 10 0 0">
+				<StackPanel Margin="10 10 0 0">
 					<TextBlock Text="{i18n:Translate ui.settings_window.labels.themes}" VerticalAlignment="Center" HorizontalAlignment="Left" Foreground="{DynamicResource ThemeForegroundBrush}" />
 					<ComboBox Name="themeComboBox" ToolTip.Tip="{Binding ToolTip_Theme}" Margin="10 10 0 10" Width="150" Background="{DynamicResource ThemeBackgroundBrush}" Foreground="{DynamicResource ThemeForegroundBrush}" BorderBrush="{DynamicResource HighlightBrush}" HorizontalAlignment="Left"/>
 					<TextBlock Text="{i18n:Translate ui.settings_window.labels.languages}" VerticalAlignment="Center" HorizontalAlignment="Left" Foreground="{DynamicResource ThemeForegroundBrush}" />
@@ -205,7 +202,7 @@
 					<ComboBox Name="groupingComboBox" ToolTip.Tip="{Binding ToolTip_Grouping}" Margin="10 10 0 0" Width="150" Background="{DynamicResource ThemeBackgroundBrush}" Foreground="{DynamicResource ThemeForegroundBrush}" BorderBrush="{DynamicResource HighlightBrush}" HorizontalAlignment="Left"/>
 				</StackPanel>
 
-				<StackPanel Grid.Row="3" Margin="10 25 0 0">
+				<StackPanel Margin="10 25 0 0">
 					<TextBlock Text="{i18n:Translate ui.settings_window.labels.nexus}" VerticalAlignment="Center" HorizontalAlignment="Left" Foreground="{DynamicResource ThemeForegroundBrush}" />
 					<StackPanel Orientation="Horizontal" IsVisible="{Binding ShowNexusServers}">
 						<TextBlock Text="{i18n:Translate ui.settings_window.labels.preferred_server}" VerticalAlignment="Center" HorizontalAlignment="Left" Foreground="{DynamicResource ThemeForegroundBrush}" />
@@ -215,7 +212,7 @@
 					<CheckBox Name="askBeforeNXMInstallCheckbox" IsChecked="{Binding IsAskingBeforeAcceptingNXM}" Content="{i18n:Translate ui.settings_window.buttons.always_ask_for_NXM_installs}" ToolTip.Tip="{Binding ToolTip_AlwaysAskNXMFiles}" VerticalAlignment="Center" HorizontalAlignment="Left" Foreground="{DynamicResource ThemeForegroundBrush}" />
 				</StackPanel>
 
-				<StackPanel Grid.Row="4" Margin="10 25 0 0">
+				<StackPanel Margin="10 25 0 0">
 					<TextBlock Text="{i18n:Translate ui.settings_window.labels.miscellaneous}" VerticalAlignment="Center" HorizontalAlignment="Left" Foreground="{DynamicResource ThemeForegroundBrush}" />
 					<CheckBox Name="ignoreHiddenFoldersCheckbox" IsChecked="{Binding IgnoreHiddenFolders}" Content="{i18n:Translate ui.settings_window.buttons.ignore_hidden_folders}" ToolTip.Tip="{Binding ToolTip_IgnoreHiddenFolders}" VerticalAlignment="Center" HorizontalAlignment="Left" Foreground="{DynamicResource ThemeForegroundBrush}" />
 					<CheckBox Name="enableProfileSpecificModConfigsCheckbox" IsChecked="{Binding EnableProfileSpecificModConfigs}" Content="{i18n:Translate ui.settings_window.buttons.enable_profile_specific_mod_configs}" ToolTip.Tip="{Binding ToolTip_EnableProfileSpecificModConfigs}" VerticalAlignment="Center" HorizontalAlignment="Left" Foreground="{DynamicResource ThemeForegroundBrush}" />
@@ -226,10 +223,10 @@
 			</StackPanel>
 		</ScrollViewer>
 
-		<Border Grid.Row="5"  BorderBrush="{DynamicResource HighlightBrush}" BorderThickness="0 0 0 2" Grid.ColumnSpan="2"/>
-		<DockPanel Grid.Row="6" Grid.Column="1"  Margin="0 0 0 0">
-			<Button Name="applyButton" ToolTip.Tip="{Binding ToolTip_Save}" i:Attached.Icon="mdi-check" Margin="0 0 15 0" BorderBrush="{DynamicResource HighlightBrush}" Foreground="Green" Background="Transparent" HorizontalAlignment="Right"/>
-			<Button Name="cancelButton" IsCancel="True" ToolTip.Tip="{Binding ToolTip_Cancel}" i:Attached.Icon="mdi-cancel" Margin="0 0 15 0" BorderBrush="{DynamicResource HighlightBrush}" Foreground="Red" Background="Transparent" HorizontalAlignment="Right"/>
-		</DockPanel>
+		<Border Grid.Row="2" Grid.ColumnSpan="2" BorderBrush="{DynamicResource HighlightBrush}" BorderThickness="0 0 0 2" Height="4"/>
+        <Grid Grid.Row="3" Grid.ColumnSpan="2" RowDefinitions="Auto, Auto" ColumnDefinitions="Auto, Auto" HorizontalAlignment="Right" Margin="0 15 0 15">
+            <Button Name="applyButton" Grid.Row="1" Grid.Column="0" ToolTip.Tip="{Binding ToolTip_Save}" i:Attached.Icon="mdi-check" Margin="0 0 15 0" BorderBrush="{DynamicResource HighlightBrush}" Foreground="Green" Background="Transparent" HorizontalAlignment="Right"/>
+			<Button Name="cancelButton" Grid.Row="1" Grid.Column="1" IsCancel="True" ToolTip.Tip="{Binding ToolTip_Cancel}" i:Attached.Icon="mdi-cancel" Margin="0 0 15 0" BorderBrush="{DynamicResource HighlightBrush}" Foreground="Red" Background="Transparent" HorizontalAlignment="Right"/>
+        </Grid>
 	</Grid>
 </Window>

--- a/Stardrop/Views/SettingsWindow.axaml.cs
+++ b/Stardrop/Views/SettingsWindow.axaml.cs
@@ -25,7 +25,6 @@ namespace Stardrop.Views
         public SettingsWindow()
         {
             InitializeComponent();
-            this.SizeToContent = SizeToContent.Height;
 
             // Set the datacontext
             DataContext = new SettingsWindowViewModel();
@@ -127,6 +126,12 @@ namespace Stardrop.Views
 #if DEBUG
             this.AttachDevTools();
 #endif
+        }
+
+        public SettingsWindow(Window parentWindow) : this()
+        {
+            // Adjust the height of the this window to be slightly smaller than the parent
+            this.Height = parentWindow.Height - (parentWindow.Height / 4);
         }
 
         private async void RegisterNXMButton_Click(object? sender, RoutedEventArgs e)

--- a/Stardrop/Views/SettingsWindow.axaml.cs
+++ b/Stardrop/Views/SettingsWindow.axaml.cs
@@ -128,10 +128,10 @@ namespace Stardrop.Views
 #endif
         }
 
-        public SettingsWindow(Window parentWindow) : this()
+        public SettingsWindow(double parentWindowHeight) : this()
         {
             // Adjust the height of the this window to be slightly smaller than the parent
-            this.Height = parentWindow.Height - (parentWindow.Height / 4);
+            this.Height = parentWindowHeight - (parentWindowHeight / 4);
         }
 
         private async void RegisterNXMButton_Click(object? sender, RoutedEventArgs e)


### PR DESCRIPTION
Minor fix, unrelated to my other PR. Allows the Settings window's content to expand vertically, along with the window.

|Before|After|
|------|------|
| ![before](https://github.com/Floogen/Stardrop/assets/5133649/ad573fc1-bff3-4681-a275-ecee5f36359a) | ![after](https://github.com/Floogen/Stardrop/assets/5133649/ee7d3a9d-87ca-4972-b115-c16980798ecf) |

Note: the `Height` set in `SettingsWindow.axaml` gets ignored because `SizeToContent` is set to `SizeToContent.Height`. If we want the window to open up to the height of `500` as set, we'll need to remove that from the constructor.