### PR TITLE
Eight new themes added

### DIFF
--- a/Stardrop/Themes/CASH MONEY.xaml
+++ b/Stardrop/Themes/CASH MONEY.xaml
@@ -1,0 +1,66 @@
+﻿<Styles
+    xmlns="https://github.com/avaloniaui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <Styles.Resources>
+
+        <!-- Base Colors -->
+        <Color x:Key="GreenBg">#4FA57E</Color>
+        <Color x:Key="GreenRow">#6AB892</Color>
+        <Color x:Key="GreenRowAlt">#74C29B</Color>
+        <Color x:Key="GreenText">#0F241C</Color>
+
+        <!-- Accent / UI Colors -->
+        <Color x:Key="SelectedGreen">#C6E0D3</Color>
+        <Color x:Key="MintHover">#8AD3AF</Color>
+        <Color x:Key="StemBorder">#3E7F62</Color>
+        <Color x:Key="DeepGreen">#2E5F4B</Color>
+
+        <Color x:Key="SystemAccentColor">#6AB892</Color>
+
+        <!-- Avalonia Brushes -->
+        <SolidColorBrush x:Key="ThemeBackgroundBrush"
+                         Color="{DynamicResource GreenBg}" />
+        <SolidColorBrush x:Key="ThemeForegroundBrush"
+                         Color="{DynamicResource GreenText}" />
+        <SolidColorBrush x:Key="ThemeControlMidBrush"
+                         Color="{DynamicResource GreenRowAlt}" />
+        <SolidColorBrush x:Key="ThemeControlHighBrush"
+                         Color="{DynamicResource GreenText}"
+                         Opacity="0.65" />
+        <SolidColorBrush x:Key="ThemeForegroundLowBrush"
+                         Color="{DynamicResource GreenText}"
+                         Opacity="0.6" />
+        <SolidColorBrush x:Key="HighlightBrush"
+                         Color="{DynamicResource StemBorder}" />
+        <SolidColorBrush x:Key="HighlightForegroundBrush"
+                         Color="{DynamicResource GreenText}" />
+
+    </Styles.Resources>
+
+    <!-- DataGrid -->
+    <Style Selector="DataGrid">
+        <Setter Property="Background" Value="{DynamicResource GreenBg}" />
+        <Setter Property="BorderBrush" Value="{DynamicResource StemBorder}" />
+        <Setter Property="Foreground" Value="{DynamicResource GreenText}" />
+    </Style>
+
+    <Style Selector="DataGridRow">
+        <Setter Property="Background" Value="{DynamicResource GreenRow}" />
+        <Setter Property="Foreground" Value="{DynamicResource GreenText}" />
+    </Style>
+
+    <Style Selector="DataGridRow:nth-child(even)">
+        <Setter Property="Background" Value="{DynamicResource GreenRowAlt}" />
+    </Style>
+
+    <Style Selector="DataGridRow:selected">
+        <Setter Property="Background" Value="{DynamicResource SelectedGreen}" />
+        <Setter Property="Foreground" Value="{DynamicResource GreenText}" />
+    </Style>
+
+    <Style Selector="DataGridRow:pointerover">
+        <Setter Property="Background" Value="{DynamicResource MintHover}" />
+    </Style>
+
+</Styles>

--- a/Stardrop/Themes/Cerene Dark.xaml
+++ b/Stardrop/Themes/Cerene Dark.xaml
@@ -1,0 +1,58 @@
+﻿<Styles
+    xmlns="https://github.com/avaloniaui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:system="clr-namespace:System;assembly=System.Runtime">
+
+    <Style>
+        <Style.Resources>
+
+            <!-- Base Colors -->
+            <Color x:Key="NightBlack">#2B313C</Color>        <!-- Main background -->
+            <Color x:Key="OffBlack">#343B48</Color>          <!-- Panels / rows -->
+            <Color x:Key="DarkestGray">#252A34</Color>       <!-- Deep background -->
+            <Color x:Key="DarkGray">#3A4252</Color>          <!-- Headers -->
+            <Color x:Key="OffGray">#40485A</Color>           <!-- Alt rows -->
+            <Color x:Key="PerfectGray">#5E677A</Color>       <!-- Subtle borders -->
+            <Color x:Key="White">#E6E9EF</Color>             <!-- Primary text -->
+
+            <!-- Accent / UI Colors -->
+            <Color x:Key="NeonMint">#8FD4A1</Color>          <!-- Enabled checkmarks -->
+            <Color x:Key="CalmBlue">#6FA8DC</Color>          <!-- Highlights -->
+            <Color x:Key="NeonRed">#D96C6C</Color>           <!-- Errors -->
+            <Color x:Key="NeonYellow">#D7D18B</Color>        <!-- Warnings -->
+            <Color x:Key="GrayBlue">#6FA3B8</Color>          <!-- Links / focus -->
+            <Color x:Key="DarkPurple">#3B3F5C</Color>        <!-- Rare accents -->
+
+            <!-- Avalonia Brushes -->
+            <SolidColorBrush x:Key="ThemeBackgroundBrush" Color="{DynamicResource NightBlack}" />
+            <SolidColorBrush x:Key="ThemeForegroundBrush" Color="{DynamicResource White}" />
+            <SolidColorBrush x:Key="HighlightBrush" Color="{DynamicResource OffBlack}" />
+            <SolidColorBrush x:Key="HighlightForegroundBrush" Color="{DynamicResource CalmBlue}" />
+
+            <SolidColorBrush x:Key="ThemeControlMidBrush" Color="{DynamicResource PerfectGray}" />
+            <SolidColorBrush x:Key="ThemeControlMidHighBrush" Color="{DynamicResource White}" Opacity="0.25" />
+            <SolidColorBrush x:Key="ThemeForegroundHighBrush" Color="{DynamicResource White}" />
+            <SolidColorBrush x:Key="ThemeControlHighBrush" Color="{DynamicResource White}" Opacity="0.65" />
+            <SolidColorBrush x:Key="ThemeControlVeryHighBrush" Color="{DynamicResource White}" Opacity="0.75" />
+            <SolidColorBrush x:Key="ThemeAccentBrush" Color="{DynamicResource White}" Opacity="0.2" />
+            <SolidColorBrush x:Key="ThemeForegroundLowBrush" Color="{DynamicResource White}" Opacity="0.35" />
+
+            <!-- DataGrid -->
+            <SolidColorBrush x:Key="DataGridHeaderBrush" Color="{DynamicResource DarkGray}" />
+            <SolidColorBrush x:Key="DataGridRowBackground" Color="{DynamicResource OffBlack}" />
+            <SolidColorBrush x:Key="AlternativeDataGridRowBackground" Color="{DynamicResource OffGray}" />
+            <SolidColorBrush x:Key="DataGridRowForeground" Color="{DynamicResource White}" />
+
+            <!-- ComboBox -->
+            <SolidColorBrush x:Key="ComboBoxItemBackgroundBrush" Color="{DynamicResource DarkGray}" />
+            <SolidColorBrush x:Key="ComboBoxItemSelectedBackgroundBrush" Color="{DynamicResource GrayBlue}" />
+
+            <!-- Status -->
+            <SolidColorBrush x:Key="UpdateAvailableBrush" Color="{DynamicResource NeonMint}" />
+            <SolidColorBrush x:Key="UpdateBrokenBrush" Color="{DynamicResource NeonRed}" />
+            <SolidColorBrush x:Key="UpdateUnofficialBrush" Color="{DynamicResource NeonYellow}" />
+
+        </Style.Resources>
+    </Style>
+
+</Styles>

--- a/Stardrop/Themes/Cerene Light.xaml
+++ b/Stardrop/Themes/Cerene Light.xaml
@@ -1,0 +1,71 @@
+﻿<Styles
+    xmlns="https://github.com/avaloniaui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <Styles.Resources>
+
+        <!-- Base Colors -->
+        <Color x:Key="IceBg">#F6FAFF</Color>
+        <Color x:Key="IceRow">#EEF3FF</Color>
+        <Color x:Key="IceRowAlt">#E6EDFF</Color>
+        <Color x:Key="IceText">#1E2433</Color>
+
+        <!-- Accent / UI Colors -->
+        <Color x:Key="RRed">#FF5F5F</Color>
+        <Color x:Key="ROrange">#FF9F43</Color>
+        <Color x:Key="RYellow">#FFD93D</Color>
+        <Color x:Key="RGreen">#4EDEA3</Color>
+        <Color x:Key="RCyan">#3FD9FF</Color>
+        <Color x:Key="RBlue">#5C7CFA</Color>
+        <Color x:Key="RPurple">#B197FC</Color>
+
+        <!-- Avalonia Brushes -->
+        <SolidColorBrush x:Key="ThemeBackgroundBrush" Color="{DynamicResource IceBg}" />
+        <SolidColorBrush x:Key="ThemeForegroundBrush" Color="{DynamicResource IceText}" />
+        <SolidColorBrush x:Key="ThemeControlMidBrush" Color="{DynamicResource IceRowAlt}" />
+        <SolidColorBrush x:Key="ThemeControlHighBrush" Color="{DynamicResource IceText}" Opacity="0.65" />
+        <SolidColorBrush x:Key="ThemeForegroundLowBrush" Color="{DynamicResource IceText}" Opacity="0.6" />
+
+    </Styles.Resources>
+
+    <!-- DataGrid -->
+    <Style Selector="DataGrid">
+        <Setter Property="Background" Value="{DynamicResource IceBg}" />
+        <Setter Property="BorderBrush" Value="{DynamicResource RCyan}" />
+        <Setter Property="Foreground" Value="{DynamicResource IceText}" />
+    </Style>
+
+    <Style Selector="DataGridRow">
+        <Setter Property="Background" Value="{DynamicResource IceRow}" />
+        <Setter Property="Foreground" Value="{DynamicResource IceText}" />
+    </Style>
+
+    <Style Selector="DataGridRow:nth-child(even)">
+        <Setter Property="Background" Value="{DynamicResource IceRowAlt}" />
+    </Style>
+
+    <Style Selector="DataGridRow:selected">
+        <Setter Property="Background">
+            <LinearGradientBrush StartPoint="0,0" EndPoint="1,0">
+                <GradientStop Color="{DynamicResource RRed}" Offset="0.0" />
+                <GradientStop Color="{DynamicResource ROrange}" Offset="0.16" />
+                <GradientStop Color="{DynamicResource RYellow}" Offset="0.33" />
+                <GradientStop Color="{DynamicResource RGreen}" Offset="0.5" />
+                <GradientStop Color="{DynamicResource RCyan}" Offset="0.66" />
+                <GradientStop Color="{DynamicResource RBlue}" Offset="0.83" />
+                <GradientStop Color="{DynamicResource RPurple}" Offset="1.0" />
+            </LinearGradientBrush>
+        </Setter>
+        <Setter Property="Foreground" Value="{DynamicResource IceText}" />
+    </Style>
+
+    <Style Selector="DataGridRow:pointerover">
+        <Setter Property="Background">
+            <LinearGradientBrush StartPoint="0,0" EndPoint="1,0" Opacity="0.4">
+                <GradientStop Color="{DynamicResource RCyan}" Offset="0.0" />
+                <GradientStop Color="{DynamicResource RBlue}" Offset="1.0" />
+            </LinearGradientBrush>
+        </Setter>
+    </Style>
+
+</Styles>

--- a/Stardrop/Themes/Dark Cherry Chocolate.xaml
+++ b/Stardrop/Themes/Dark Cherry Chocolate.xaml
@@ -1,0 +1,84 @@
+﻿<Styles
+    xmlns="https://github.com/avaloniaui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:system="clr-namespace:System;assembly=System.Runtime">
+
+    <Style>
+        <Style.Resources>
+
+            <!-- Base Colors -->
+            <Color x:Key="NightBlack">#2E2326</Color>
+            <Color x:Key="OffBlack">#3A2B30</Color>
+            <Color x:Key="DarkestGray">#24191D</Color>
+            <Color x:Key="DarkGray">#46323A</Color>
+            <Color x:Key="OffGray">#4A353D</Color>
+            <Color x:Key="PerfectGray">#6E5860</Color>
+            <Color x:Key="White">#EFE6EA</Color>
+
+            <!-- Accent / UI Colors -->
+            <Color x:Key="NeonMint">#CFA3B4</Color>
+            <Color x:Key="CalmBlue">#B57A8C</Color>
+            <Color x:Key="NeonRed">#C96C7D</Color>
+            <Color x:Key="NeonYellow">#D6B3A2</Color>
+            <Color x:Key="GrayBlue">#C08FA0</Color>
+            <Color x:Key="DarkPurple">#3B2A30</Color>
+
+            <!-- Avalonia Brushes -->
+            <SolidColorBrush x:Key="ThemeBackgroundBrush"
+                             Color="{DynamicResource NightBlack}" />
+            <SolidColorBrush x:Key="ThemeForegroundBrush"
+                             Color="{DynamicResource White}" />
+
+            <SolidColorBrush x:Key="HighlightBrush"
+                             Color="{DynamicResource OffBlack}" />
+            <SolidColorBrush x:Key="HighlightForegroundBrush"
+                             Color="{DynamicResource CalmBlue}" />
+
+            <SolidColorBrush x:Key="ThemeControlMidBrush"
+                             Color="{DynamicResource PerfectGray}" />
+            <SolidColorBrush x:Key="ThemeControlMidHighBrush"
+                             Color="{DynamicResource White}"
+                             Opacity="0.25" />
+            <SolidColorBrush x:Key="ThemeForegroundHighBrush"
+                             Color="{DynamicResource White}" />
+            <SolidColorBrush x:Key="ThemeControlHighBrush"
+                             Color="{DynamicResource White}"
+                             Opacity="0.65" />
+            <SolidColorBrush x:Key="ThemeControlVeryHighBrush"
+                             Color="{DynamicResource White}"
+                             Opacity="0.75" />
+            <SolidColorBrush x:Key="ThemeAccentBrush"
+                             Color="{DynamicResource White}"
+                             Opacity="0.2" />
+            <SolidColorBrush x:Key="ThemeForegroundLowBrush"
+                             Color="{DynamicResource White}"
+                             Opacity="0.35" />
+
+            <!-- DataGrid -->
+            <SolidColorBrush x:Key="DataGridHeaderBrush"
+                             Color="{DynamicResource DarkGray}" />
+            <SolidColorBrush x:Key="DataGridRowBackground"
+                             Color="{DynamicResource OffBlack}" />
+            <SolidColorBrush x:Key="AlternativeDataGridRowBackground"
+                             Color="{DynamicResource OffGray}" />
+            <SolidColorBrush x:Key="DataGridRowForeground"
+                             Color="{DynamicResource White}" />
+
+            <!-- ComboBox -->
+            <SolidColorBrush x:Key="ComboBoxItemBackgroundBrush"
+                             Color="{DynamicResource DarkGray}" />
+            <SolidColorBrush x:Key="ComboBoxItemSelectedBackgroundBrush"
+                             Color="{DynamicResource GrayBlue}" />
+
+            <!-- Status -->
+            <SolidColorBrush x:Key="UpdateAvailableBrush"
+                             Color="{DynamicResource NeonMint}" />
+            <SolidColorBrush x:Key="UpdateBrokenBrush"
+                             Color="{DynamicResource NeonRed}" />
+            <SolidColorBrush x:Key="UpdateUnofficialBrush"
+                             Color="{DynamicResource NeonYellow}" />
+
+        </Style.Resources>
+    </Style>
+
+</Styles>

--- a/Stardrop/Themes/Fairy.xaml
+++ b/Stardrop/Themes/Fairy.xaml
@@ -1,0 +1,84 @@
+﻿<Styles
+    xmlns="https://github.com/avaloniaui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:system="clr-namespace:System;assembly=System.Runtime">
+
+    <Style>
+        <Style.Resources>
+
+            <!-- Base Colors -->
+            <Color x:Key="NightBlack">#F6ECEF</Color>
+            <Color x:Key="OffBlack">#EFE3E8</Color>
+            <Color x:Key="DarkestGray">#E5D7DD</Color>
+            <Color x:Key="DarkGray">#DDD0D6</Color>
+            <Color x:Key="OffGray">#F8EEF2</Color>
+            <Color x:Key="PerfectGray">#C8B8BF</Color>
+            <Color x:Key="White">#3A2A31</Color>
+
+            <!-- Accent / UI Colors -->
+            <Color x:Key="NeonMint">#E8B8C9</Color>
+            <Color x:Key="CalmBlue">#F0B4CB</Color>
+            <Color x:Key="NeonRed">#D98AA4</Color>
+            <Color x:Key="NeonYellow">#EAD3C6</Color>
+            <Color x:Key="GrayBlue">#F3C9D9</Color>
+            <Color x:Key="DarkPurple">#8A6675</Color>
+
+            <!-- Avalonia Brushes -->
+            <SolidColorBrush x:Key="ThemeBackgroundBrush"
+                             Color="{DynamicResource NightBlack}" />
+            <SolidColorBrush x:Key="ThemeForegroundBrush"
+                             Color="{DynamicResource White}" />
+
+            <SolidColorBrush x:Key="HighlightBrush"
+                             Color="{DynamicResource OffBlack}" />
+            <SolidColorBrush x:Key="HighlightForegroundBrush"
+                             Color="{DynamicResource CalmBlue}" />
+
+            <SolidColorBrush x:Key="ThemeControlMidBrush"
+                             Color="{DynamicResource PerfectGray}" />
+            <SolidColorBrush x:Key="ThemeControlMidHighBrush"
+                             Color="{DynamicResource White}"
+                             Opacity="0.18" />
+            <SolidColorBrush x:Key="ThemeForegroundHighBrush"
+                             Color="{DynamicResource White}" />
+            <SolidColorBrush x:Key="ThemeControlHighBrush"
+                             Color="{DynamicResource White}"
+                             Opacity="0.4" />
+            <SolidColorBrush x:Key="ThemeControlVeryHighBrush"
+                             Color="{DynamicResource White}"
+                             Opacity="0.6" />
+            <SolidColorBrush x:Key="ThemeAccentBrush"
+                             Color="{DynamicResource White}"
+                             Opacity="0.12" />
+            <SolidColorBrush x:Key="ThemeForegroundLowBrush"
+                             Color="{DynamicResource White}"
+                             Opacity="0.65" />
+
+            <!-- DataGrid -->
+            <SolidColorBrush x:Key="DataGridHeaderBrush"
+                             Color="{DynamicResource DarkGray}" />
+            <SolidColorBrush x:Key="DataGridRowBackground"
+                             Color="{DynamicResource OffBlack}" />
+            <SolidColorBrush x:Key="AlternativeDataGridRowBackground"
+                             Color="{DynamicResource OffGray}" />
+            <SolidColorBrush x:Key="DataGridRowForeground"
+                             Color="{DynamicResource White}" />
+
+            <!-- ComboBox -->
+            <SolidColorBrush x:Key="ComboBoxItemBackgroundBrush"
+                             Color="{DynamicResource DarkGray}" />
+            <SolidColorBrush x:Key="ComboBoxItemSelectedBackgroundBrush"
+                             Color="{DynamicResource GrayBlue}" />
+
+            <!-- Status -->
+            <SolidColorBrush x:Key="UpdateAvailableBrush"
+                             Color="{DynamicResource NeonMint}" />
+            <SolidColorBrush x:Key="UpdateBrokenBrush"
+                             Color="{DynamicResource NeonRed}" />
+            <SolidColorBrush x:Key="UpdateUnofficialBrush"
+                             Color="{DynamicResource NeonYellow}" />
+
+        </Style.Resources>
+    </Style>
+
+</Styles>

--- a/Stardrop/Themes/Forest.xaml
+++ b/Stardrop/Themes/Forest.xaml
@@ -1,0 +1,79 @@
+﻿<Styles
+    xmlns="https://github.com/avaloniaui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:system="clr-namespace:System;assembly=System.Runtime">
+
+    <Style>
+        <Style.Resources>
+
+            <!-- Base Colors -->
+            <Color x:Key="NightBlack">#2B2118</Color>
+            <Color x:Key="OffBlack">#33271D</Color>
+            <Color x:Key="DarkestGray">#241B14</Color>
+            <Color x:Key="DarkGray">#3B2E23</Color>
+            <Color x:Key="OffGray">#413327</Color>
+            <Color x:Key="PerfectGray">#6A5B4C</Color>
+            <Color x:Key="White">#E6E2DD</Color>
+
+            <!-- Accent / UI Colors -->
+            <Color x:Key="NeonMint">#8FBFA3</Color>
+            <Color x:Key="CalmBlue">#6F9E86</Color>
+            <Color x:Key="NeonRed">#C97A6A</Color>
+            <Color x:Key="NeonYellow">#CBBF87</Color>
+            <Color x:Key="GrayBlue">#7FAF95</Color>
+            <Color x:Key="DarkPurple">#3E352C</Color>
+
+            <!-- Avalonia Brushes -->
+            <SolidColorBrush x:Key="ThemeBackgroundBrush"
+                             Color="{DynamicResource NightBlack}" />
+            <SolidColorBrush x:Key="ThemeForegroundBrush"
+                             Color="{DynamicResource White}" />
+
+            <SolidColorBrush x:Key="HighlightBrush"
+                             Color="{DynamicResource OffBlack}" />
+            <SolidColorBrush x:Key="HighlightForegroundBrush"
+                             Color="{DynamicResource CalmBlue}" />
+
+            <SolidColorBrush x:Key="ThemeControlMidBrush"
+                             Color="{DynamicResource PerfectGray}" />
+            <SolidColorBrush x:Key="ThemeControlMidHighBrush"
+                             Color="{DynamicResource White}" Opacity="0.25" />
+            <SolidColorBrush x:Key="ThemeForegroundHighBrush"
+                             Color="{DynamicResource White}" />
+            <SolidColorBrush x:Key="ThemeControlHighBrush"
+                             Color="{DynamicResource White}" Opacity="0.65" />
+            <SolidColorBrush x:Key="ThemeControlVeryHighBrush"
+                             Color="{DynamicResource White}" Opacity="0.75" />
+            <SolidColorBrush x:Key="ThemeAccentBrush"
+                             Color="{DynamicResource White}" Opacity="0.2" />
+            <SolidColorBrush x:Key="ThemeForegroundLowBrush"
+                             Color="{DynamicResource White}" Opacity="0.35" />
+
+            <!-- DataGrid -->
+            <SolidColorBrush x:Key="DataGridHeaderBrush"
+                             Color="{DynamicResource DarkGray}" />
+            <SolidColorBrush x:Key="DataGridRowBackground"
+                             Color="{DynamicResource OffBlack}" />
+            <SolidColorBrush x:Key="AlternativeDataGridRowBackground"
+                             Color="{DynamicResource OffGray}" />
+            <SolidColorBrush x:Key="DataGridRowForeground"
+                             Color="{DynamicResource White}" />
+
+            <!-- ComboBox -->
+            <SolidColorBrush x:Key="ComboBoxItemBackgroundBrush"
+                             Color="{DynamicResource DarkGray}" />
+            <SolidColorBrush x:Key="ComboBoxItemSelectedBackgroundBrush"
+                             Color="{DynamicResource GrayBlue}" />
+
+            <!-- Status -->
+            <SolidColorBrush x:Key="UpdateAvailableBrush"
+                             Color="{DynamicResource NeonMint}" />
+            <SolidColorBrush x:Key="UpdateBrokenBrush"
+                             Color="{DynamicResource NeonRed}" />
+            <SolidColorBrush x:Key="UpdateUnofficialBrush"
+                             Color="{DynamicResource NeonYellow}" />
+
+        </Style.Resources>
+    </Style>
+
+</Styles>

--- a/Stardrop/Themes/Light (Pink).xaml
+++ b/Stardrop/Themes/Light (Pink).xaml
@@ -1,0 +1,84 @@
+﻿<Styles
+    xmlns="https://github.com/avaloniaui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:system="clr-namespace:System;assembly=System.Runtime">
+
+    <Style>
+        <Style.Resources>
+
+            <!-- Base Colors -->
+            <Color x:Key="NightBlack">#FAF3F6</Color>
+            <Color x:Key="OffBlack">#F2E6EB</Color>
+            <Color x:Key="DarkestGray">#E8D8DE</Color>
+            <Color x:Key="DarkGray">#DEC9D2</Color>
+            <Color x:Key="OffGray">#F8EFF3</Color>
+            <Color x:Key="PerfectGray">#C9B5BE</Color>
+            <Color x:Key="White">#3B2A31</Color>
+
+            <!-- Accent / UI Colors -->
+            <Color x:Key="NeonMint">#E9B9C9</Color>
+            <Color x:Key="CalmBlue">#F1B6CD</Color>
+            <Color x:Key="NeonRed">#DB8FA6</Color>
+            <Color x:Key="NeonYellow">#ECD6C9</Color>
+            <Color x:Key="GrayBlue">#F4CEDC</Color>
+            <Color x:Key="DarkPurple">#8E6A78</Color>
+
+            <!-- Avalonia Brushes -->
+            <SolidColorBrush x:Key="ThemeBackgroundBrush"
+                             Color="{DynamicResource NightBlack}" />
+            <SolidColorBrush x:Key="ThemeForegroundBrush"
+                             Color="{DynamicResource White}" />
+
+            <SolidColorBrush x:Key="HighlightBrush"
+                             Color="{DynamicResource OffBlack}" />
+            <SolidColorBrush x:Key="HighlightForegroundBrush"
+                             Color="{DynamicResource CalmBlue}" />
+
+            <SolidColorBrush x:Key="ThemeControlMidBrush"
+                             Color="{DynamicResource PerfectGray}" />
+            <SolidColorBrush x:Key="ThemeControlMidHighBrush"
+                             Color="{DynamicResource White}"
+                             Opacity="0.18" />
+            <SolidColorBrush x:Key="ThemeForegroundHighBrush"
+                             Color="{DynamicResource White}" />
+            <SolidColorBrush x:Key="ThemeControlHighBrush"
+                             Color="{DynamicResource White}"
+                             Opacity="0.4" />
+            <SolidColorBrush x:Key="ThemeControlVeryHighBrush"
+                             Color="{DynamicResource White}"
+                             Opacity="0.6" />
+            <SolidColorBrush x:Key="ThemeAccentBrush"
+                             Color="{DynamicResource White}"
+                             Opacity="0.12" />
+            <SolidColorBrush x:Key="ThemeForegroundLowBrush"
+                             Color="{DynamicResource White}"
+                             Opacity="0.65" />
+
+            <!-- DataGrid -->
+            <SolidColorBrush x:Key="DataGridHeaderBrush"
+                             Color="{DynamicResource DarkGray}" />
+            <SolidColorBrush x:Key="DataGridRowBackground"
+                             Color="{DynamicResource OffBlack}" />
+            <SolidColorBrush x:Key="AlternativeDataGridRowBackground"
+                             Color="{DynamicResource OffGray}" />
+            <SolidColorBrush x:Key="DataGridRowForeground"
+                             Color="{DynamicResource White}" />
+
+            <!-- ComboBox -->
+            <SolidColorBrush x:Key="ComboBoxItemBackgroundBrush"
+                             Color="{DynamicResource DarkGray}" />
+            <SolidColorBrush x:Key="ComboBoxItemSelectedBackgroundBrush"
+                             Color="{DynamicResource GrayBlue}" />
+
+            <!-- Status -->
+            <SolidColorBrush x:Key="UpdateAvailableBrush"
+                             Color="{DynamicResource NeonMint}" />
+            <SolidColorBrush x:Key="UpdateBrokenBrush"
+                             Color="{DynamicResource NeonRed}" />
+            <SolidColorBrush x:Key="UpdateUnofficialBrush"
+                             Color="{DynamicResource NeonYellow}" />
+
+        </Style.Resources>
+    </Style>
+
+</Styles>

--- a/Stardrop/Themes/Light Cherry Chocolate.xaml
+++ b/Stardrop/Themes/Light Cherry Chocolate.xaml
@@ -1,0 +1,86 @@
+﻿<Styles
+    xmlns="https://github.com/avaloniaui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:system="clr-namespace:System;assembly=System.Runtime">
+
+    <Style>
+        <Style.Resources>
+
+        <!-- Base Colors -->
+            <Color x:Key="NightBlack">#3A2F34</Color>        
+            <Color x:Key="OffBlack">#4A3A41</Color>          
+            <Color x:Key="DarkestGray">#2F2428</Color>       
+            <Color x:Key="DarkGray">#5A454D</Color>          
+            <Color x:Key="OffGray">#5F4850</Color>           
+            <Color x:Key="PerfectGray">#8A717B</Color>       
+            <Color x:Key="White">#F6EDF1</Color>             
+
+ 
+            <!-- Accent / UI Colors -->
+            <Color x:Key="NeonMint">#D8A8BC</Color>
+            <Color x:Key="CalmBlue">#E2A3BE</Color>          
+            <Color x:Key="NeonRed">#E08AA2</Color>
+            <Color x:Key="NeonYellow">#E8C6B8</Color>
+            <Color x:Key="GrayBlue">#E6B4C8</Color>
+            <Color x:Key="DarkPurple">#4A343C</Color>
+
+            <!-- Avalonia brushes -->
+            <SolidColorBrush x:Key="ThemeBackgroundBrush"
+                             Color="{DynamicResource NightBlack}" />
+            <SolidColorBrush x:Key="ThemeForegroundBrush"
+                             Color="{DynamicResource White}" />
+
+            <!-- Selection behavior preserved -->
+            <SolidColorBrush x:Key="HighlightBrush"
+                             Color="{DynamicResource OffBlack}" />
+            <SolidColorBrush x:Key="HighlightForegroundBrush"
+                             Color="{DynamicResource CalmBlue}" />
+
+            <SolidColorBrush x:Key="ThemeControlMidBrush"
+                             Color="{DynamicResource PerfectGray}" />
+            <SolidColorBrush x:Key="ThemeControlMidHighBrush"
+                             Color="{DynamicResource White}"
+                             Opacity="0.25" />
+            <SolidColorBrush x:Key="ThemeForegroundHighBrush"
+                             Color="{DynamicResource White}" />
+            <SolidColorBrush x:Key="ThemeControlHighBrush"
+                             Color="{DynamicResource White}"
+                             Opacity="0.65" />
+            <SolidColorBrush x:Key="ThemeControlVeryHighBrush"
+                             Color="{DynamicResource White}"
+                             Opacity="0.75" />
+            <SolidColorBrush x:Key="ThemeAccentBrush"
+                             Color="{DynamicResource White}"
+                             Opacity="0.2" />
+            <SolidColorBrush x:Key="ThemeForegroundLowBrush"
+                             Color="{DynamicResource White}"
+                             Opacity="0.35" />
+
+            <!-- DataGrid -->
+            <SolidColorBrush x:Key="DataGridHeaderBrush"
+                             Color="{DynamicResource DarkGray}" />
+            <SolidColorBrush x:Key="DataGridRowBackground"
+                             Color="{DynamicResource OffBlack}" />
+            <SolidColorBrush x:Key="AlternativeDataGridRowBackground"
+                             Color="{DynamicResource OffGray}" />
+            <SolidColorBrush x:Key="DataGridRowForeground"
+                             Color="{DynamicResource White}" />
+
+            <!-- ComboBox -->
+            <SolidColorBrush x:Key="ComboBoxItemBackgroundBrush"
+                             Color="{DynamicResource DarkGray}" />
+            <SolidColorBrush x:Key="ComboBoxItemSelectedBackgroundBrush"
+                             Color="{DynamicResource GrayBlue}" />
+
+            <!-- Status -->
+            <SolidColorBrush x:Key="UpdateAvailableBrush"
+                             Color="{DynamicResource NeonMint}" />
+            <SolidColorBrush x:Key="UpdateBrokenBrush"
+                             Color="{DynamicResource NeonRed}" />
+            <SolidColorBrush x:Key="UpdateUnofficialBrush"
+                             Color="{DynamicResource NeonYellow}" />
+
+        </Style.Resources>
+    </Style>
+
+</Styles>


### PR DESCRIPTION
Eight new themes:

**Cerene Dark**
<img width="1980" height="1283" alt="Cerene Dark-Preview" src="https://github.com/user-attachments/assets/8e55093b-25f3-45e5-bbf5-58e145b0cb63" />

**Cerene Light**
<img width="1936" height="1239" alt="Cerene Light-Preview" src="https://github.com/user-attachments/assets/a0654214-253d-44cb-9d12-96d5844e0ec6" />

**Light (Pink)**
<img width="1936" height="1239" alt="Light (Pink)-Preview" src="https://github.com/user-attachments/assets/a1ef806f-7229-4076-8aba-9d1c2b32cc0d" />

**Fairy**
<img width="1936" height="1239" alt="Fairy-Preview" src="https://github.com/user-attachments/assets/659caa10-2513-4163-b92c-26a587cce297" />

**Light Cherry Chocolate**
<img width="1936" height="1239" alt="Light Cherry Chocolate-Preview" src="https://github.com/user-attachments/assets/7b59691f-fab0-458d-89a9-85e250a17eb4" />

**Dark Cherry Chocolate**
<img width="1936" height="1239" alt="Dark Cherry Chocolate-Preview" src="https://github.com/user-attachments/assets/b3d9814b-c573-44d9-944d-702b3fe7cda7" />

**Forest**
<img width="1980" height="1283" alt="Forest-Preview" src="https://github.com/user-attachments/assets/c1595fde-f01c-49ab-90ba-5e0442abc5a9" />

**CASH MONEY**
<img width="1980" height="1283" alt="CASH MONEY-Preview" src="https://github.com/user-attachments/assets/9c0b08f5-b9b1-4d5c-8f75-3f01f378f5b3" />
